### PR TITLE
fix(#5): allow relative imports within the same slice, restrict cross…

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,8 @@ src/
 
 ```
 
-> 💡 Tip: The plugin enforces correct layer imports according to FSD principles. For example, a feature can depend on entities and shared, but cannot directly import another feature.
+> 💡 Tip: The plugin enforces correct layer imports according to FSD principles. For example, a feature can depend on entities and shared, but cannot directly import another feature.<br/>  
+> Relative imports are allowed **only within the same slice**, but must be avoided across different slices or layers.
 
 ---
 
@@ -151,7 +152,7 @@ Each rule helps maintain a **clear module structure, enforce import constraints,
 | Rule | Description |
 |------|------------|
 | **fsd/forbidden-imports** | Prevents imports from higher layers and cross-imports between slices. |
-| **fsd/no-relative-imports** | Enforces alias usage instead of relative imports (`../../shared/ui`). |
+| **fsd/no-relative-imports** | Disallows relative imports across different slices or layers. Allows relative imports within the same slice. |
 | **fsd/no-public-api-sidestep** | Prevents direct imports from internal modules, enforcing public API usage. |
 | **fsd/no-cross-slice-dependency** | Disallows direct dependencies between feature slices. |
 | **fsd/no-ui-in-business-logic** | Prevents UI imports inside business logic layers (e.g., `entities`). |
@@ -184,12 +185,14 @@ Disallows relative imports and enforces alias usage. <br/>
 ❌ Not Allowed: Using ../ or ./ <br/>
 
 ```javascript
-// ❌ Incorrect (relative import)
-import { Button } from "../shared/ui/Button";
+// ❌ Incorrect (relative import across different slices)
+import { fetchUser } from "../another-slice/model/api";
 
-// ✅ Correct (alias import)
+// ✅ Correct (relative import within the same slice)
+import { fetchData } from "../model/api";
+
+// ✅ Correct (alias import across slices or layers)
 import { Button } from "@shared/ui/Button";
-
 ```
 
 <br/>

--- a/src/rules/no-relative-imports.js
+++ b/src/rules/no-relative-imports.js
@@ -1,13 +1,15 @@
+import path from "path";
+
 export default {
   meta: {
     type: "problem",
     docs: {
-      description: "Disallows relative imports and enforces the use of project-defined aliases.",
+      description: "Disallows relative imports across different slices in Feature-Sliced Design.",
       recommended: true,
     },
     messages: {
       noRelativePath:
-        "🚨 Relative import '{{ importPath }}' is not allowed. Use an alias instead.",
+        "🚨 Relative import '{{ importPath }}' is not allowed across different slices. Use an alias instead.",
     },
   },
 
@@ -16,16 +18,52 @@ export default {
       ImportDeclaration(node) {
         const importPath = node.source.value;
 
-        // Detects relative imports (starting with ../ or ./)
-        if (importPath.startsWith("../") || importPath.startsWith("./")) {
-          context.report({
-            node,
-            messageId: "noRelativePath",
-            data: {
-              importPath,
-            },
-          });
+        // Check if the import path is a relative path
+        if (!importPath.startsWith("../") && !importPath.startsWith("./")) {
+          return; // Skip if it's not a relative import
         }
+
+        const currentFilePath = context.getFilename();
+        const projectRoot = path.resolve(process.cwd(), "src"); // Project root directory (src)
+
+        // Resolve the absolute path of the imported file
+        const absoluteImportPath = path.resolve(path.dirname(currentFilePath), importPath);
+
+        if (!absoluteImportPath.startsWith(projectRoot)) {
+          return; // Skip checking files outside the src directory
+        }
+
+        // Compute relative paths for the current file and the import target
+        const relativePath = path.relative(projectRoot, currentFilePath);
+        const relativeImportTarget = path.relative(projectRoot, absoluteImportPath);
+
+        // Extract the first two folder names (Layer and Slice)
+        const getLayerAndSlice = (filePath) => {
+          const parts = filePath.split(path.sep);
+          return parts.length >= 2 ? { layer: parts[0], slice: parts[1] } : null;
+        };
+
+        const currentLocation = getLayerAndSlice(relativePath);
+        const importLocation = getLayerAndSlice(relativeImportTarget);
+
+        // Ignore cases where layer and slice information cannot be determined
+        if (!currentLocation || !importLocation) {
+          return;
+        }
+
+        // Allow imports within the same slice
+        if (currentLocation.layer === importLocation.layer && currentLocation.slice === importLocation.slice) {
+          return;
+        }
+
+        // Report an error if the relative import is crossing different slices
+        context.report({
+          node,
+          messageId: "noRelativePath",
+          data: {
+            importPath,
+          },
+        });
       },
     };
   },


### PR DESCRIPTION
fix(#5): allow relative imports within the same slice, restrict cross-slice and cross-layer imports

Previously, all relative imports were forbidden. This update ensures that relative imports are allowed only within the same slice while enforcing alias usage for cross-slice and cross-layer imports.

## Description
<!-- 
Provide a concise summary of the changes in this PR.
Keep it brief but informative. If the PR fixes an issue, reference it (e.g., "Fixes #123").
-->
This PR updates the `fsd/no-relative-imports` rule to allow relative imports within the same slice while restricting cross-slice and cross-layer relative imports.  
Fixes #5.

## Changes
<!-- 
List the key changes introduced in this PR.
Use bullet points to make it easy to read.
-->
- Allowed relative imports within the same slice (`../model`, `./ui`, etc.).
- Enforced alias usage (`@features/`, `@shared/`) for cross-slice and cross-layer imports.
- Updated rule logic to analyze slice and layer structure.
- Improved ESLint rule messages for better clarity.
- Added absolute path resolution to ensure correct rule enforcement.

## Before / After
<!-- 
Provide a comparison of the behavior before and after the change.
Use tables or code snippets if applicable.
-->

### **Before**
| Import Type | Behavior |
|-------------|----------|
| `import { fetchData } from "../model/api";` (same slice) | ❌ Not allowed |
| `import { fetchUser } from "../registration/model/api";` (cross-slice) | ❌ Not allowed |
| `import { formatDate } from "../../shared/utils/date";` (cross-layer) | ❌ Not allowed |

### **After**
| Import Type | Behavior |
|-------------|----------|
| `import { fetchData } from "../model/api";` (same slice) | ✅ Allowed |
| `import { fetchUser } from "../registration/model/api";` (cross-slice) | ❌ Not allowed |
| `import { formatDate } from "../../shared/utils/date";` (cross-layer) | ❌ Not allowed |

## Type of Change
<!-- 
Mark the type of change by selecting one of the following:
-->
- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactoring
- [ ] Other (describe below)

## How to Test
<!-- 
Describe how the changes were tested.
Provide steps to verify the functionality.
-->
1. Run `npm test` or `pnpm test` to execute ESLint rule tests.
2. Check if relative imports within the same slice are correctly allowed.
3. Verify that cross-slice and cross-layer relative imports trigger ESLint errors.
4. Ensure alias imports (`@features/`, `@shared/`) continue to work correctly.

## Additional Information
<!-- 
Include any extra details, such as potential side effects or dependencies.
-->
- This update aligns the rule enforcement with Feature-Sliced Design (FSD) principles.
- No breaking changes, as alias imports remain the recommended approach.
- Future updates may include configuration options for finer-grained control.
