### PR TITLE
fix: recommended config doesn't work

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,15 +25,18 @@ export const rules = {
 export const configs = {
   // Recommended configuration
   recommended: {
-    plugins: ['fsd-lint'],
-    rules: {
-      'fsd-lint/forbidden-imports': 'error',
-      'fsd-lint/no-cross-slice-dependency': 'error',
-      'fsd-lint/no-global-store-imports': 'error',
-      'fsd-lint/no-public-api-sidestep': 'error',
-      'fsd-lint/no-relative-imports': 'error',
-      'fsd-lint/no-ui-in-business-logic': 'error',
-      'fsd-lint/ordered-imports': 'warn'
+    plugins: {
+      'fsd-lint': {
+        rules: {
+          'fsd-lint/forbidden-imports': 'error',
+          'fsd-lint/no-cross-slice-dependency': 'error',
+          'fsd-lint/no-global-store-imports': 'error',
+          'fsd-lint/no-public-api-sidestep': 'error',
+          'fsd-lint/no-relative-imports': 'error',
+          'fsd-lint/no-ui-in-business-logic': 'error',
+          'fsd-lint/ordered-imports': 'warn'
+        }
+      }
     }
   },
 


### PR DESCRIPTION
## Description
`configs.recommended`를 사용하면 에러가 발생합니다.

## Changes
`plugins` 필드를 `Object`로 수정합니다.

## Before / After

이런 설정일 때,
```typescript
import fsdLint from 'eslint-plugin-fsd-lint';

export default [
  fsdLint.configs.recommended,

  // 기타 생략
];
```

아래와 같은 에러가 발생합니다.
```
A config object has a "plugins" key defined as an array of strings. It looks something like this:

    {
        "plugins": ["fsd-lint"]
    }

Flat config requires "plugins" to be an object, like this:

    {
        plugins: {
            fsd-lint: pluginObject
        }
    }
```

## Type of Change
- [ ] Documentation
- [X] Bug fix
- [ ] Feature
- [ ] Refactoring
- [ ] Other (describe below)

## How to Test
`test-project` 폴더에서 수정 해서 테스트 해봤습니다.

## Additional Information
