### PR TITLE
feat: added rootPath property

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -153,6 +153,7 @@ export default [
       'fsd/forbidden-imports': [
         'error',
         {
+          rootPath: '/src/root/',
           // @shared 또는 @/shared 형식 모두 지원
           alias: {
             value: '@',

--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ export default [
       'fsd/forbidden-imports': [
         'error',
         {
+          // Support for custom root directory
+          rootPath: '/src/root/',
           // Support for @shared or @/shared import styles
           alias: {
             value: '@',

--- a/src/rules/forbidden-imports.js
+++ b/src/rules/forbidden-imports.js
@@ -21,6 +21,7 @@ export default {
         type: "object",
         properties: {
           alias: {
+            rootPath: { type: "string" },
             oneOf: [
               { type: "string" },
               {

--- a/src/rules/no-cross-slice-dependency.js
+++ b/src/rules/no-cross-slice-dependency.js
@@ -29,6 +29,7 @@ export default {
       {
         type: 'object',
         properties: {
+          rootPath: { type: 'string' },
           featuresOnly: {
             type: 'boolean',
             description: 'If true, only check dependencies between feature slices',

--- a/src/rules/no-ui-in-business-logic.js
+++ b/src/rules/no-ui-in-business-logic.js
@@ -19,6 +19,7 @@ export default {
       {
         type: 'object',
         properties: {
+          rootPath: { type: 'string' },
           testFilesPatterns: {
             type: 'array',
             items: { type: 'string' },

--- a/src/utils/config-utils.js
+++ b/src/utils/config-utils.js
@@ -10,6 +10,9 @@ export const defaultConfig = {
     withSlash: false  // Default to @shared format
   },
 
+  // Default root path
+  rootPath: "/src/",
+
   // Layer definitions and priorities
   layers: {
     app: { pattern: "app", priority: 1, allowedToImport: ["processes", "pages", "widgets", "features", "entities", "shared"] },
@@ -116,10 +119,14 @@ export function mergeConfig(userConfig = {}) {
     ...(userConfig.relativePath || {})
   };
 
+  // Merge root path
+  const rootPath = userConfig.rootPath || defaultConfig.rootPath;
+
   // Return final configuration
   return {
     alias,
     layers,
+    rootPath,
     folderPattern,
     testFilesPatterns,
     publicApi,

--- a/src/utils/path-utils.js
+++ b/src/utils/path-utils.js
@@ -117,7 +117,7 @@ export function extractLayerFromImportPath(importPath, config) {
  * @return {string|null} - Extracted layer name or null
  */
 export function extractLayerFromPath(filePath, config) {
-  const relativePath = getRelativePathFromRoot(filePath);
+  const relativePath = getRelativePathFromRoot(filePath, config.rootPath);
   if (!relativePath) return null;
 
   const firstDir = relativePath.split('/')[0];


### PR DESCRIPTION
## Description
Added the ability to pass a custom `rootPath` for cases when the project is not in the src root, but in another child directory.

## Changes
Added `rootPath` property in rules:
- `forbidden-imports`
- `no-cross-slice-dependency`
- `no-ui-in-business-logic`

## Before / After
Before:
- Unable to set a custom path to the project directory

After:
- Сan specify a custom path to the project directory

## Type of Change
- [ ] Documentation
- [ ] Bug fix
- [x] Feature
- [ ] Refactoring
- [ ] Other (describe below)

## How to Test
I made the changes and tested it in the `test-project` folder.
