### PR TITLE
refactor: use context properties instead of methods

### DIFF
--- a/src/rules/forbidden-imports.js
+++ b/src/rules/forbidden-imports.js
@@ -2,8 +2,8 @@
  * @fileoverview Layer imports rule - Enforces layer dependency direction in FSD architecture
  */
 
-import { extractLayerFromPath, extractLayerFromImportPath, isTestFile, normalizePath } from '../utils/path-utils.js';
 import { mergeConfig } from '../utils/config-utils.js';
+import { extractLayerFromImportPath, extractLayerFromPath, isTestFile, normalizePath } from '../utils/path-utils.js';
 
 export default {
   meta: {
@@ -80,7 +80,7 @@ export default {
 
     return {
       ImportDeclaration(node) {
-        const filePath = normalizePath(context.getFilename());
+        const filePath = normalizePath(context.filename);
         const importPath = node.source.value;
 
         // Skip test files

--- a/src/rules/no-cross-slice-dependency.js
+++ b/src/rules/no-cross-slice-dependency.js
@@ -2,15 +2,15 @@
  * @fileoverview Prevents direct dependencies between slices in the same layer. Each slice should be isolated.
  */
 
-import {
-  extractLayerFromPath,
-  extractLayerFromImportPath,
-  extractSliceFromPath,
-  isTestFile,
-  normalizePath,
-  isRelativePath,
-} from '../utils/path-utils.js';
 import { mergeConfig } from '../utils/config-utils.js';
+import {
+    extractLayerFromImportPath,
+    extractLayerFromPath,
+    extractSliceFromPath,
+    isRelativePath,
+    isTestFile,
+    normalizePath,
+} from '../utils/path-utils.js';
 
 export default {
   meta: {
@@ -76,7 +76,7 @@ export default {
 
     return {
       ImportDeclaration(node) {
-        const filePath = normalizePath(context.getFilename());
+        const filePath = normalizePath(context.filename);
         const importPath = node.source.value;
 
         // Skip test files
@@ -275,7 +275,7 @@ export default {
           }
 
           // Skip test files
-          if (isTestFile(context.getFilename(), config.testFilesPatterns)) {
+          if (isTestFile(context.filename, config.testFilesPatterns)) {
             return;
           }
 
@@ -290,7 +290,7 @@ export default {
           }
 
           // Extract current file's layer
-          const fromLayer = extractLayerFromPath(context.getFilename(), config);
+          const fromLayer = extractLayerFromPath(context.filename, config);
 
           // Skip excluded layers
           if (!fromLayer || excludeLayers.has(fromLayer)) {
@@ -303,7 +303,7 @@ export default {
           }
 
           // Extract current file's slice
-          const fromSlice = extractSliceFromPath(context.getFilename(), config);
+          const fromSlice = extractSliceFromPath(context.filename, config);
           if (!fromSlice) {
             return;
           }

--- a/src/rules/no-global-store-imports.js
+++ b/src/rules/no-global-store-imports.js
@@ -2,8 +2,8 @@
  * @fileoverview Disallows direct imports of global state (store). Use hooks or selectors instead.
  */
 
-import { normalizePath, isTestFile } from '../utils/path-utils.js';
 import { mergeConfig } from '../utils/config-utils.js';
+import { isTestFile, normalizePath } from '../utils/path-utils.js';
 
 export default {
   meta: {
@@ -61,7 +61,7 @@ export default {
 
     return {
       ImportDeclaration(node) {
-        const filePath = normalizePath(context.getFilename());
+        const filePath = normalizePath(context.filename);
         const importPath = node.source.value;
 
         // Skip test files - tests typically need direct store access

--- a/src/rules/no-public-api-sidestep.js
+++ b/src/rules/no-public-api-sidestep.js
@@ -2,8 +2,8 @@
  * @fileoverview Prevents direct imports from internal files of modules. Use public API (index) instead.
  */
 
-import { extractLayerFromPath, extractLayerFromImportPath, normalizePath, isTestFile } from '../utils/path-utils.js';
 import { mergeConfig } from '../utils/config-utils.js';
+import { extractLayerFromImportPath, isTestFile, normalizePath } from '../utils/path-utils.js';
 
 export default {
   meta: {
@@ -82,7 +82,7 @@ export default {
 
     return {
       ImportDeclaration(node) {
-        const filePath = normalizePath(context.getFilename());
+        const filePath = normalizePath(context.filename);
         const importPath = node.source.value;
 
         // Skip test files
@@ -133,14 +133,14 @@ export default {
         const layerIndex = pathParts.findIndex((part) => {
           const normalizedPart = normalizePath(part);
           // Check if the part contains the layer (e.g., @entities contains entities)
-          return normalizedPart === importLayer || 
-                 normalizedPart.includes(importLayer) || 
+          return normalizedPart === importLayer ||
+                 normalizedPart.includes(importLayer) ||
                  config.layers[importLayer]?.pattern === normalizedPart;
         });
 
         // If import only specifies layer and slice, it's considered a public API import
         const isSliceRootImport = layerIndex >= 0 && pathParts.length === layerIndex + 2;
-        
+
         // Check if it's importing from a segment level (e.g., @entities/user/model, @entities/user/ui, @entities/user/anySegmentName)
         // Any segment name is allowed in FSD architecture
         const isSegmentImport = layerIndex >= 0 && pathParts.length === layerIndex + 3;
@@ -169,7 +169,7 @@ export default {
           }
 
           // Skip test files
-          if (isTestFile(context.getFilename(), config.testFilesPatterns)) {
+          if (isTestFile(context.filename, config.testFilesPatterns)) {
             return;
           }
 
@@ -205,14 +205,14 @@ export default {
           const layerIndex = pathParts.findIndex((part) => {
             const normalizedPart = normalizePath(part);
             // Check if the part contains the layer (e.g., @entities contains entities)
-            return normalizedPart === importLayer || 
-                   normalizedPart.includes(importLayer) || 
+            return normalizedPart === importLayer ||
+                   normalizedPart.includes(importLayer) ||
                    config.layers[importLayer]?.pattern === normalizedPart;
           });
 
           // If import only specifies layer and slice, it's considered a public API import
           const isSliceRootImport = layerIndex >= 0 && pathParts.length === layerIndex + 2;
-          
+
           // Check if it's importing from a segment level (e.g., @entities/user/model, @entities/user/ui, @entities/user/anySegmentName)
           // Any segment name is allowed in FSD architecture
           const isSegmentImport = layerIndex >= 0 && pathParts.length === layerIndex + 3;

--- a/src/rules/no-relative-imports.js
+++ b/src/rules/no-relative-imports.js
@@ -2,9 +2,9 @@
  * @fileoverview Prevents relative imports between slices. All imports should use absolute paths with aliases.
  */
 
-import { isRelativePath, isTestFile, normalizePath } from '../utils/path-utils.js';
-import { mergeConfig } from '../utils/config-utils.js';
 import path from 'path';
+import { mergeConfig } from '../utils/config-utils.js';
+import { isRelativePath, isTestFile, normalizePath } from '../utils/path-utils.js';
 
 export default {
   meta: {
@@ -65,16 +65,16 @@ export default {
 
       // FSD layers we need to check
       const fsdLayers = ['app', 'processes', 'pages', 'widgets', 'features', 'entities', 'shared'];
-      
+
       // Layers that don't have slices (single-layer modules)
       const singleLayerModules = ['app', 'shared'];
-      
+
       // Find layer and slice from current file path
       const currentPathParts = normalizedCurrentPath.split('/');
       let currentLayer = null;
       let currentSlice = null;
       let layerIndex = -1;
-      
+
       for (let i = 0; i < currentPathParts.length; i++) {
         if (fsdLayers.includes(currentPathParts[i])) {
           currentLayer = currentPathParts[i];
@@ -86,22 +86,22 @@ export default {
           break;
         }
       }
-      
+
       // If we couldn't find a layer, we can't determine if it's same slice
       if (!currentLayer || layerIndex === -1) return false;
-      
+
       // For single-layer modules (app, shared), any import within the layer is allowed
       if (singleLayerModules.includes(currentLayer)) {
         // Check if the resolved import is within the same layer
         return resolvedImportPath.includes(`/${currentLayer}/`);
       }
-      
+
       // Find layer and slice from resolved import path
       const resolvedPathParts = resolvedImportPath.split('/');
       let importLayer = null;
       let importSlice = null;
       let importLayerIndex = -1;
-      
+
       for (let i = 0; i < resolvedPathParts.length; i++) {
         if (fsdLayers.includes(resolvedPathParts[i])) {
           importLayer = resolvedPathParts[i];
@@ -113,7 +113,7 @@ export default {
           break;
         }
       }
-      
+
       // If we couldn't find a layer in the import, it might be within the same slice
       if (!importLayer || importLayerIndex === -1) {
         // Check if the resolved path is still within the current layer/slice structure
@@ -124,12 +124,12 @@ export default {
           return resolvedImportPath.includes(`/${currentLayer}/`);
         }
       }
-      
+
       // For single-layer modules, just check if layers match
       if (singleLayerModules.includes(currentLayer) || singleLayerModules.includes(importLayer)) {
         return currentLayer === importLayer;
       }
-      
+
       // Check if both layer and slice match
       return currentLayer === importLayer && currentSlice === importSlice;
     }
@@ -144,7 +144,7 @@ export default {
         }
 
         // Skip test files
-        if (isTestFile(context.getFilename(), config.testFilesPatterns)) {
+        if (isTestFile(context.filename, config.testFilesPatterns)) {
           return;
         }
 
@@ -164,7 +164,7 @@ export default {
         }
 
         // Skip same slice imports if configured
-        if (allowSameSlice && isSameSlice(importPath, context.getFilename())) {
+        if (allowSameSlice && isSameSlice(importPath, context.filename)) {
           return;
         }
 
@@ -184,7 +184,7 @@ export default {
           }
 
           // Skip test files
-          if (isTestFile(context.getFilename(), config.testFilesPatterns)) {
+          if (isTestFile(context.filename, config.testFilesPatterns)) {
             return;
           }
 
@@ -202,7 +202,7 @@ export default {
           // as that information is not available at parse time
 
           // Skip same slice imports if configured
-          if (allowSameSlice && isSameSlice(importPath, context.getFilename())) {
+          if (allowSameSlice && isSameSlice(importPath, context.filename)) {
             return;
           }
 

--- a/src/rules/no-ui-in-business-logic.js
+++ b/src/rules/no-ui-in-business-logic.js
@@ -2,8 +2,8 @@
  * @fileoverview Prevents importing UI components in business logic layers (model, api, lib).
  */
 
-import { extractLayerFromPath, isTestFile, normalizePath } from '../utils/path-utils.js';
 import { mergeConfig } from '../utils/config-utils.js';
+import { extractLayerFromPath, isTestFile, normalizePath } from '../utils/path-utils.js';
 
 export default {
   meta: {
@@ -62,7 +62,7 @@ export default {
 
     return {
       ImportDeclaration(node) {
-        const filePath = normalizePath(context.getFilename());
+        const filePath = normalizePath(context.filename);
         const importPath = node.source.value;
 
         // Skip test files
@@ -109,7 +109,7 @@ export default {
       CallExpression(node) {
         // Handle dynamic imports
         if (node.callee.type === 'Import') {
-          const filePath = normalizePath(context.getFilename());
+          const filePath = normalizePath(context.filename);
           const importPath = node.arguments[0].value;
 
           // Skip test files

--- a/src/rules/ordered-imports.js
+++ b/src/rules/ordered-imports.js
@@ -2,8 +2,8 @@
  * @fileoverview Enforces ordered imports by Feature-Sliced Design (FSD) layers
  */
 
-import { normalizePath, extractLayerFromImportPath } from '../utils/path-utils.js';
 import { mergeConfig } from '../utils/config-utils.js';
+import { extractLayerFromImportPath } from '../utils/path-utils.js';
 
 export default {
   meta: {
@@ -70,7 +70,7 @@ export default {
           return;
         }
 
-        const sourceCode = context.sourceCode || context.getSourceCode();
+        const sourceCode = context.sourceCode;
         const sourceText = sourceCode.getText();
         const sourceLines = sourceText.split("\n");
 

--- a/test-project/package-lock.json
+++ b/test-project/package-lock.json
@@ -34,8 +34,7 @@
       }
     },
     "..": {
-      "name": "eslint-plugin-fsd-lint",
-      "version": "1.0.8",
+      "version": "1.0.11",
       "dev": true,
       "license": "MIT",
       "devDependencies": {


### PR DESCRIPTION
## Description
Refactors the code to use the ESLint v9 context properties, as described [here](https://eslint.org/blog/2023/09/preparing-custom-rules-eslint-v9/#context-methods-becoming-properties), and includes some other very minor fixes.

## Changes
- Replaced the deprecated `context.getFilename()` calls with `context.filename`.
- Removed the deprecated `context.getSourceCode()` fallback in `ordered-imports`.
- Removed the unused `normalizePath` import from `ordered-imports`.
- Updated `test-project/package-lock.json` so the test project references plugin version `1.0.11`.

## Before / After
| Before | After |
| --- | --- |
| Several files used deprecated `context.getFilename()` calls. | Files now use `context.filename`, matching the ESLint v9 recommendations. |
| `ordered-imports` kept an unused `normalizePath` import. | `ordered-imports` uses only the imports it needs. |
| `ordered-imports` had a deprecated `context.getSourceCode()` fallback. | `ordered-imports` now only uses `context.sourceCode` matching the ESLint v9 recommendations. |
| The test project lockfile pointed at an older plugin version. | The test project lockfile now references the latest plugin version (`1.0.11`). |

## Type of Change
- [ ] Documentation
- [ ] Bug fix
- [ ] Feature
- [x] Refactoring
- [x] Other

## How to Test
1. Run `npm install` in the repository root if dependencies are not installed. ✅
2. Run `npm test` to execute the Vitest suite. ✅
3. Run `npm run lint` to verify the rule files still pass linting. ❌ - The root project doesn't have eslint config so can't run linting there.
4. Optionally inspect a sample project with this plugin enabled and confirm the affected rules behave the same as before. ✅ - Ran it in the test project and it gave the same errors as in main. 

## Additional Information
No user-facing rule behavior is expected to change in this PR. 
The main goal is API modernization and cleanup for ESLint compatibility. 
Which might also make the plugin work with ESlint v10, which removes these deprecated methods.

⚠️ The reason this isn't a breaking change is because these methods were introduced in ESlint v8.40, and this plugin seems to me to only support v9 and higher.

However if this plugin is intending to support versions lower than <v8.40 as well, then it is a breaking change!
