### PR TITLE
fix: stabilize lint tooling after formatting merge

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,7 +3,7 @@ import globals from "globals";
 
 export default [
   {
-    ignores: ["**/node_modules/**", "html/**"],
+    ignores: ["**/node_modules/**", "html/**", "test-project/**"],
   },
   eslint.configs.recommended,
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,11 @@
       "version": "1.0.11",
       "license": "MIT",
       "devDependencies": {
+        "@eslint/js": "^9.39.4",
         "@typescript-eslint/parser": "^8.25.0",
         "@vitest/ui": "^3.0.7",
         "eslint": "^9.21.0",
+        "globals": "^14.0.0",
         "prettier": "3.8.1",
         "vitest": "^3.0.7"
       },
@@ -539,13 +541,16 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.21.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.21.0.tgz",
-      "integrity": "sha512-BqStZ3HX8Yz6LvsF5ByXYrtigrV5AXADWLAGc7PH/1SxOb7/FIYYMszZZWiUou/GB9P2lXWk2SV4d+Z8h0nknw==",
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/@eslint/object-schema": {
@@ -1627,6 +1632,16 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/@eslint/js": {
+      "version": "9.21.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.21.0.tgz",
+      "integrity": "sha512-BqStZ3HX8Yz6LvsF5ByXYrtigrV5AXADWLAGc7PH/1SxOb7/FIYYMszZZWiUou/GB9P2lXWk2SV4d+Z8h0nknw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/espree": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "src/index.js",
   "type": "module",
   "scripts": {
-    "lint": "eslint . && cd test-project && npm run lint",
+    "lint": "eslint .",
+    "lint:test-project": "cd test-project && npm run lint",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
@@ -23,9 +24,11 @@
   "author": "effozen",
   "license": "MIT",
   "devDependencies": {
+    "@eslint/js": "^9.39.4",
     "@typescript-eslint/parser": "^8.25.0",
     "@vitest/ui": "^3.0.7",
     "eslint": "^9.21.0",
+    "globals": "^14.0.0",
     "prettier": "3.8.1",
     "vitest": "^3.0.7"
   },

--- a/src/rules/forbidden-imports.js
+++ b/src/rules/forbidden-imports.js
@@ -2,8 +2,13 @@
  * @fileoverview Layer imports rule - Enforces layer dependency direction in FSD architecture
  */
 
-import { mergeConfig } from '../utils/config-utils.js';
-import { extractLayerFromImportPath, extractLayerFromPath, isTestFile, normalizePath } from '../utils/path-utils.js';
+import { mergeConfig } from "../utils/config-utils.js";
+import {
+  extractLayerFromImportPath,
+  extractLayerFromPath,
+  isTestFile,
+  normalizePath,
+} from "../utils/path-utils.js";
 
 export default {
   meta: {
@@ -112,7 +117,6 @@ export default {
 
         // Get layer priorities and allowed imports
         const fromLayerConfig = config.layers[fromLayer];
-        const toLayerConfig = config.layers[toLayer];
 
         // Get list of allowed imports
         const allowedToImport = fromLayerConfig.allowedToImport || [];

--- a/src/rules/no-cross-slice-dependency.js
+++ b/src/rules/no-cross-slice-dependency.js
@@ -2,15 +2,15 @@
  * @fileoverview Prevents direct dependencies between slices in the same layer. Each slice should be isolated.
  */
 
-import { mergeConfig } from '../utils/config-utils.js';
+import { mergeConfig } from "../utils/config-utils.js";
 import {
-    extractLayerFromImportPath,
-    extractLayerFromPath,
-    extractSliceFromPath,
-    isRelativePath,
-    isTestFile,
-    normalizePath,
-} from '../utils/path-utils.js';
+  extractLayerFromImportPath,
+  extractLayerFromPath,
+  extractSliceFromPath,
+  isRelativePath,
+  isTestFile,
+  normalizePath,
+} from "../utils/path-utils.js";
 
 export default {
   meta: {

--- a/src/rules/no-global-store-imports.js
+++ b/src/rules/no-global-store-imports.js
@@ -2,8 +2,8 @@
  * @fileoverview Disallows direct imports of global state (store). Use hooks or selectors instead.
  */
 
-import { mergeConfig } from '../utils/config-utils.js';
-import { isTestFile, normalizePath } from '../utils/path-utils.js';
+import { mergeConfig } from "../utils/config-utils.js";
+import { isTestFile, normalizePath } from "../utils/path-utils.js";
 
 export default {
   meta: {

--- a/src/rules/no-public-api-sidestep.js
+++ b/src/rules/no-public-api-sidestep.js
@@ -2,8 +2,12 @@
  * @fileoverview Prevents direct imports from internal files of modules. Use public API (index) instead.
  */
 
-import { mergeConfig } from '../utils/config-utils.js';
-import { extractLayerFromImportPath, isTestFile, normalizePath } from '../utils/path-utils.js';
+import { mergeConfig } from "../utils/config-utils.js";
+import {
+  extractLayerFromImportPath,
+  isTestFile,
+  normalizePath,
+} from "../utils/path-utils.js";
 
 export default {
   meta: {
@@ -139,9 +143,11 @@ export default {
         const layerIndex = pathParts.findIndex((part) => {
           const normalizedPart = normalizePath(part);
           // Check if the part contains the layer (e.g., @entities contains entities)
-          return normalizedPart === importLayer ||
-                 normalizedPart.includes(importLayer) ||
-                 config.layers[importLayer]?.pattern === normalizedPart;
+          return (
+            normalizedPart === importLayer ||
+            normalizedPart.includes(importLayer) ||
+            config.layers[importLayer]?.pattern === normalizedPart
+          );
         });
 
         // If import only specifies layer and slice, it's considered a public API import
@@ -213,9 +219,11 @@ export default {
           const layerIndex = pathParts.findIndex((part) => {
             const normalizedPart = normalizePath(part);
             // Check if the part contains the layer (e.g., @entities contains entities)
-            return normalizedPart === importLayer ||
-                   normalizedPart.includes(importLayer) ||
-                   config.layers[importLayer]?.pattern === normalizedPart;
+            return (
+              normalizedPart === importLayer ||
+              normalizedPart.includes(importLayer) ||
+              config.layers[importLayer]?.pattern === normalizedPart
+            );
           });
 
           // If import only specifies layer and slice, it's considered a public API import

--- a/src/rules/no-relative-imports.js
+++ b/src/rules/no-relative-imports.js
@@ -2,9 +2,13 @@
  * @fileoverview Prevents relative imports between slices. All imports should use absolute paths with aliases.
  */
 
-import path from 'path';
-import { mergeConfig } from '../utils/config-utils.js';
-import { isRelativePath, isTestFile, normalizePath } from '../utils/path-utils.js';
+import path from "path";
+import { mergeConfig } from "../utils/config-utils.js";
+import {
+  isRelativePath,
+  isTestFile,
+  normalizePath,
+} from "../utils/path-utils.js";
 
 export default {
   meta: {
@@ -69,10 +73,18 @@ export default {
       );
 
       // FSD layers we need to check
-      const fsdLayers = ['app', 'processes', 'pages', 'widgets', 'features', 'entities', 'shared'];
+      const fsdLayers = [
+        "app",
+        "processes",
+        "pages",
+        "widgets",
+        "features",
+        "entities",
+        "shared",
+      ];
 
       // Layers that don't have slices (single-layer modules)
-      const singleLayerModules = ['app', 'shared'];
+      const singleLayerModules = ["app", "shared"];
 
       // Find layer and slice from current file path
       const currentPathParts = normalizedCurrentPath.split("/");

--- a/src/rules/no-ui-in-business-logic.js
+++ b/src/rules/no-ui-in-business-logic.js
@@ -120,7 +120,7 @@ export default {
       },
       CallExpression(node) {
         // Handle dynamic imports
-        if (node.callee.type === 'Import') {
+        if (node.callee.type === "Import") {
           const filePath = normalizePath(context.filename);
           const importPath = node.arguments[0].value;
 

--- a/src/rules/ordered-imports.js
+++ b/src/rules/ordered-imports.js
@@ -2,8 +2,8 @@
  * @fileoverview Enforces ordered imports by Feature-Sliced Design (FSD) layers
  */
 
-import { mergeConfig } from '../utils/config-utils.js';
-import { extractLayerFromImportPath } from '../utils/path-utils.js';
+import { mergeConfig } from "../utils/config-utils.js";
+import { extractLayerFromImportPath } from "../utils/path-utils.js";
 
 export default {
   meta: {

--- a/test-project/eslint.config.js
+++ b/test-project/eslint.config.js
@@ -5,6 +5,15 @@ import reactPlugin from "eslint-plugin-react";
 import fsdPlugin from "eslint-plugin-fsd-lint";
 
 export default [
+  {
+    ignores: [
+      "src/examples/**",
+      "src/**/__tests__/**",
+      "src/features/auth/model/authService.ts",
+      "src/features/auth/ui/LoginFormContainer.tsx",
+      "src/features/profile/model/profileService.ts",
+    ],
+  },
   eslint.configs.recommended,
   {
     files: ["**/*.ts", "**/*.tsx"],
@@ -15,6 +24,13 @@ export default [
     },
     languageOptions: {
       parser: tsparser,
+      globals: {
+        console: "readonly",
+        document: "readonly",
+        HTMLButtonElement: "readonly",
+        HTMLElement: "readonly",
+        setTimeout: "readonly",
+      },
       parserOptions: {
         ecmaVersion: 2022,
         sourceType: "module",
@@ -29,6 +45,7 @@ export default [
       },
     },
     rules: {
+      "no-unused-vars": "off",
       "fsd/forbidden-imports": "error",
       "fsd/no-relative-imports": [
         "error",

--- a/test-project/src/app/index.tsx
+++ b/test-project/src/app/index.tsx
@@ -10,11 +10,11 @@ import { LoginPage } from "@pages/login";
 import { Header } from "@widgets/header";
 import { LoginForm } from "@features/auth";
 import { User } from "@entities/user";
-import { Button } from "@shared/ui/Button";
 
 // ✅ VALID: Import from custom segments
 import { userService } from "@entities/user/services";
 import { validateEmail } from "@entities/user/validators";
+import { Button } from "@shared/ui/Button";
 
 const App = () => {
   return (

--- a/test-project/src/app/store/index.ts
+++ b/test-project/src/app/store/index.ts
@@ -1,6 +1,6 @@
 import { configureStore } from "@reduxjs/toolkit";
-import { userReducer } from "@entities/user";
 import { authReducer } from "@features/auth";
+import { userReducer } from "@entities/user";
 
 export const store = configureStore({
   reducer: {

--- a/test-project/src/pages/dashboard/ui/DashboardPage.tsx
+++ b/test-project/src/pages/dashboard/ui/DashboardPage.tsx
@@ -1,5 +1,9 @@
 import React from "react";
 
+// ✅ VALID: Relative import within same slice
+import { DashboardStats } from "./components/DashboardStats";
+import { useDashboardData } from "../hooks/useDashboardData";
+
 // ✅ VALID: Import from widgets via public API
 import { Header } from "@widgets/header";
 
@@ -16,10 +20,6 @@ import { formatUserName } from "@entities/user/helpers";
 
 // ✅ VALID: Import from shared
 import { Button } from "@shared/ui/Button";
-
-// ✅ VALID: Relative import within same slice
-import { DashboardStats } from "./components/DashboardStats";
-import { useDashboardData } from "../hooks/useDashboardData";
 
 // ❌ INVALID Examples (commented out):
 // import { LoginPage } from '@pages/login'; // Cross-slice dependency in same layer

--- a/test-project/src/widgets/header/ui/Header.tsx
+++ b/test-project/src/widgets/header/ui/Header.tsx
@@ -1,14 +1,14 @@
 import React from "react";
 
-// ✅ VALID: Import from shared via alias
-import { Button } from "@shared/ui/Button";
+// ✅ VALID: Relative import within same slice
+import { useHeaderLogic } from "../model/hooks";
+import type { HeaderProps } from "../model/types";
 
 // ✅ VALID: Import from entities via public API
 import { User } from "@entities/user";
 
-// ✅ VALID: Relative import within same slice
-import { useHeaderLogic } from "../model/hooks";
-import type { HeaderProps } from "../model/types";
+// ✅ VALID: Import from shared via alias
+import { Button } from "@shared/ui/Button";
 
 export const Header: React.FC<HeaderProps> = ({ user }) => {
   const { isMenuOpen, toggleMenu } = useHeaderLogic();

--- a/tests/test-project-lint.test.js
+++ b/tests/test-project-lint.test.js
@@ -1,0 +1,86 @@
+import { ESLint } from "eslint";
+import { describe, expect, it } from "vitest";
+import tsParser from "@typescript-eslint/parser";
+
+import fsdPlugin from "../src/index.js";
+
+function createEslint() {
+  return new ESLint({
+    overrideConfigFile: true,
+    ignore: false,
+    overrideConfig: [
+      {
+        files: ["**/*.ts", "**/*.tsx"],
+        languageOptions: {
+          parser: tsParser,
+          parserOptions: {
+            ecmaVersion: 2022,
+            sourceType: "module",
+            ecmaFeatures: {
+              jsx: true,
+            },
+          },
+        },
+        plugins: {
+          fsd: fsdPlugin,
+        },
+        rules: {
+          "fsd/forbidden-imports": "error",
+          "fsd/no-relative-imports": [
+            "error",
+            {
+              allowSameSlice: true,
+            },
+          ],
+          "fsd/no-public-api-sidestep": "error",
+          "fsd/no-cross-slice-dependency": "error",
+          "fsd/no-ui-in-business-logic": "error",
+          "fsd/no-global-store-imports": "error",
+          "fsd/ordered-imports": "error",
+        },
+      },
+    ],
+  });
+}
+
+async function lintFiles(filePaths) {
+  const eslint = createEslint();
+  return eslint.lintFiles(filePaths);
+}
+
+function getRuleIds(results) {
+  return results.flatMap((result) =>
+    result.messages.map((message) => message.ruleId),
+  );
+}
+
+describe("test-project lint fixtures", () => {
+  it("keeps representative valid files free of FSD lint errors", async () => {
+    const results = await lintFiles([
+      "test-project/src/app/index.tsx",
+      "test-project/src/pages/dashboard/ui/DashboardPage.tsx",
+      "test-project/src/widgets/header/ui/Header.tsx",
+      "test-project/src/shared/ui/Button/Button.tsx",
+    ]);
+
+    expect(getRuleIds(results)).toEqual([]);
+  });
+
+  it("reports expected FSD violations from intentional invalid fixtures", async () => {
+    const results = await lintFiles([
+      "test-project/src/examples/rule-violations.ts",
+      "test-project/src/features/auth/model/authService.ts",
+      "test-project/src/features/auth/ui/LoginFormContainer.tsx",
+      "test-project/src/features/profile/model/profileService.ts",
+    ]);
+
+    expect(getRuleIds(results)).toEqual(
+      expect.arrayContaining([
+        "fsd/forbidden-imports",
+        "fsd/no-cross-slice-dependency",
+        "fsd/no-public-api-sidestep",
+        "fsd/no-relative-imports",
+      ]),
+    );
+  });
+});

--- a/tests/utils/test-utils.js
+++ b/tests/utils/test-utils.js
@@ -14,6 +14,18 @@ export const ruleTester = new RuleTester({
   },
 });
 
+function normalizeTestCase(testCase) {
+  const normalized =
+    typeof testCase === "string" ? { code: testCase } : { ...testCase };
+
+  if (normalized.description && !normalized.name) {
+    normalized.name = normalized.description;
+  }
+
+  delete normalized.description;
+  return normalized;
+}
+
 /**
  * Helper function to add filename to test cases
  * @param {string} code - Code to test
@@ -31,7 +43,7 @@ export function withFilename(code, filename) {
  * @returns {Object} - Test case with options
  */
 export function withOptions(testCase, options) {
-  return { ...testCase, options: [options] };
+  return { ...normalizeTestCase(testCase), options: [options] };
 }
 
 /**
@@ -48,7 +60,7 @@ export function testRule(ruleName, rule, tests) {
 
         try {
           ruleTester.run(`${ruleName}_valid_${index}`, rule, {
-            valid: [test],
+            valid: [normalizeTestCase(test)],
             invalid: [],
           });
         } catch (error) {
@@ -66,7 +78,7 @@ export function testRule(ruleName, rule, tests) {
         try {
           ruleTester.run(`${ruleName}_invalid_${index}`, rule, {
             valid: [],
-            invalid: [test],
+            invalid: [normalizeTestCase(test)],
           });
         } catch (error) {
           console.error(`Test failed: ${testDescription}`);


### PR DESCRIPTION
## Description

Follow-up for #19 and #20.

This PR fixes the lint and formatting regressions left after the formatting/linting merge, keeps the ESLint v10-safe rule API changes from #19, and adds focused test-project lint coverage so valid fixtures and intentional violations are checked separately.

## Changes

- Kept the ESLint v10-safe rule API usage from #19:
  - `context.filename`
  - `context.sourceCode`
- Removed the unused `toLayerConfig` variable that caused root lint to fail.
- Split root lint and test-project lint:
  - `npm run lint`
  - `npm run lint:test-project`
- Added direct root dev dependencies used by `eslint.config.js`:
  - `@eslint/js`
  - `globals`
- Updated root ESLint ignores so `test-project/**` is not picked up by root lint under ESLint v10 config lookup behavior.
- Updated test-project ESLint config to ignore intentional violation fixtures and reduce non-FSD noise.
- Fixed representative valid test-project import order for `fsd/ordered-imports`.
- Added integration tests that lint representative test-project files:
  - valid files must produce no FSD lint errors
  - intentional invalid fixtures must report expected FSD rule IDs
- Fixed `withOptions("code", options)` normalization in the rule test helper.

## Before / After

| Before | After |
| --- | --- |
| `npm run lint` failed on unused `toLayerConfig`. | `npm run lint` passes. |
| `npm run format:check` failed after conflict resolution. | `npm run format:check` passes. |
| Root lint also attempted to traverse `test-project` behavior through the same script. | Root lint and test-project lint are explicit separate scripts. |
| `test-project` lint mixed valid samples, intentional violations, browser globals, and unused variable noise. | test-project lint checks representative valid files, while intentional violations are covered by Vitest integration tests. |
| `eslint.config.js` imported packages that were not direct root dev dependencies. | `@eslint/js` and `globals` are direct root dev dependencies. |
| #19 v10-safe API changes could have regressed during #20 conflict resolution. | `context.getFilename()` and `context.getSourceCode()` are absent from `src`. |

## Type of Change

- [ ] Documentation
- [x] Bug fix
- [ ] Feature
- [x] Refactoring
- [x] Other (describe below)

Other: test coverage and tooling stabilization.

## How to Test

Run:

```bash
npm run format:check
npm run lint
npm run lint:test-project
npm test
```

Additional ESLint v10 smoke check was performed with:

```bash
eslint@10.2.0
@eslint/js@10.0.1
@typescript-eslint/parser@8.58.1
```

The following passed under that temporary v10 setup:

```bash
npm run lint
npm test
npm run format:check
```

## Additional Information

Issues raised by #19 and #20 were checked:

- #19: The deprecated ESLint rule context APIs remain removed. No `context.getFilename()` or `context.getSourceCode()` usages remain in `src`.
- #20: The remaining lint failure from `toLayerConfig` is fixed, formatting now passes, and test-project lint is handled separately with focused integration coverage.

This keeps the package compatible with ESLint v9 while making the rule implementation safe for ESLint v10.
