### PR TITLE
chore: add CI and release version validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  quality:
+    name: Quality Checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: "npm"
+          cache-dependency-path: |
+            package-lock.json
+            test-project/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install test-project dependencies
+        working-directory: test-project
+        run: npm ci
+
+      - name: Check formatting
+        run: npm run format:check
+
+      - name: Run root lint
+        run: npm run lint
+
+      - name: Run test-project lint
+        run: npm run lint:test-project
+
+      - name: Run tests
+        run: npm test

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -24,6 +24,18 @@ jobs:
           registry-url: "https://registry.npmjs.org/"
           cache: "npm"
 
+      - name: Validate release tag version
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+
+          if [ "$TAG_VERSION" != "$PACKAGE_VERSION" ]; then
+            echo "Release tag v${TAG_VERSION} does not match package.json version ${PACKAGE_VERSION}."
+            exit 1
+          fi
+
+          echo "Release tag v${TAG_VERSION} matches package.json version ${PACKAGE_VERSION}."
+
       - name: Install dependencies
         run: npm ci
 


### PR DESCRIPTION
## Description
Add GitHub Actions coverage for PR/main quality checks and harden npm releases by validating that the pushed release tag matches package.json.

## Changes
- Add a CI workflow for pull requests and pushes to main.
- Run format, root lint, test-project lint, and tests in CI.
- Add release tag/package version validation before npm publish.

## Before / After
| Before | After |
| --- | --- |
| PRs and main pushes did not run automated quality checks. | PRs and main pushes run formatting, linting, test-project linting, and tests. |
| A mismatched release tag could trigger the npm publish workflow using the package.json version. | The publish workflow fails early when the tag version and package.json version differ. |

## Type of Change
- [ ] Documentation
- [ ] Bug fix
- [ ] Feature
- [ ] Refactoring
- [x] Other (CI/CD)

## How to Test
- `git diff --check`
- `npm run format:check`
- `npm run lint`
- `npm run lint:test-project`
- `npm test`
- `actionlint .github/workflows/ci.yml .github/workflows/npm-publish.yml`
- Simulated release tag validation with matching and mismatching `GITHUB_REF_NAME` values.

## Additional Information
This does not change runtime package behavior. It only updates GitHub Actions workflows.