### PR TITLE
Add configurable public API enforcement options

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -128,7 +128,7 @@ export default [
   // 표준 권장 구성
   fsdPlugin.configs.recommended,
 
-  // 엄격한 구성 (모든 규칙이 error)
+  // 엄격한 구성 (모든 규칙이 error, slice-level Public API와 shared Public API 강제)
   // fsdPlugin.configs.strict,
 
   // 기본 구성 (덜 엄격함)
@@ -644,7 +644,7 @@ src/
 이제 여러 구성 프리셋을 사용할 수 있습니다:
 
 - `recommended` - 표준 권장 설정
-- `strict` - 최대 강제 수준
+- `strict` - 최대 강제 수준, slice-level Public API와 shared Public API 강제
 - `base` - 쉬운 도입을 위한 덜 엄격한 설정
 
 ### 6. 포괄적인 테스트 커버리지

--- a/README.ko.md
+++ b/README.ko.md
@@ -418,7 +418,7 @@ import { Button } from "@/shared/ui/Button";
 ### 3️⃣ fsd/no-public-api-sidestep
 
 features, widgets, entities의 내부 모듈을 직접 import하지 못하도록 합니다.  
-✅ 허용: index.ts(공개 API) 또는 세그먼트 레벨을 통한 import  
+✅ 기본 허용: index.ts(공개 API) 또는 세그먼트 레벨을 통한 import  
 ❌ 금지: 세그먼트 내부 파일에 직접 접근
 
 ```javascript
@@ -714,6 +714,21 @@ const { UserCard } = await import("@entities/user");
 
 // ❌ 유효하지 않음: public API를 우회하는 동적 import
 const UserCard = await import("@entities/user/ui/UserCard");
+```
+
+더 엄격한 프로젝트에서는 세그먼트 레벨 Public API import를 막고 `shared`
+레이어에도 Public API 사용을 강제할 수 있습니다.
+
+```javascript
+"fsd/no-public-api-sidestep": [
+  "error",
+  {
+    publicApi: {
+      allowSegmentImports: false,
+      enforceShared: true,
+    },
+  },
+];
 ```
 
 ---

--- a/README.ko.md
+++ b/README.ko.md
@@ -720,12 +720,18 @@ const UserCard = await import("@entities/user/ui/UserCard");
 레이어에도 Public API 사용을 강제할 수 있습니다.
 
 ```javascript
-"fsd/no-public-api-sidestep": [
-  "error",
+export default [
   {
-    publicApi: {
-      allowSegmentImports: false,
-      enforceShared: true,
+    rules: {
+      "fsd/no-public-api-sidestep": [
+        "error",
+        {
+          publicApi: {
+            allowSegmentImports: false,
+            enforceShared: true,
+          },
+        },
+      ],
     },
   },
 ];

--- a/README.ko.md
+++ b/README.ko.md
@@ -136,6 +136,80 @@ export default [
 ];
 ```
 
+<details>
+<summary>recommended 프리셋 설정</summary>
+
+```js
+{
+  plugins: {
+    fsd: fsdPlugin,
+  },
+  rules: {
+    "fsd/forbidden-imports": "error",
+    "fsd/no-cross-slice-dependency": "error",
+    "fsd/no-global-store-imports": "error",
+    "fsd/no-public-api-sidestep": "error",
+    "fsd/no-relative-imports": "error",
+    "fsd/no-ui-in-business-logic": "error",
+    "fsd/ordered-imports": "warn",
+  },
+}
+```
+
+</details>
+
+<details>
+<summary>strict 프리셋 설정</summary>
+
+```js
+{
+  plugins: {
+    fsd: fsdPlugin,
+  },
+  rules: {
+    "fsd/forbidden-imports": "error",
+    "fsd/no-cross-slice-dependency": "error",
+    "fsd/no-global-store-imports": "error",
+    "fsd/no-public-api-sidestep": [
+      "error",
+      {
+        publicApi: {
+          allowSegmentImports: false,
+          enforceShared: true,
+        },
+      },
+    ],
+    "fsd/no-relative-imports": "error",
+    "fsd/no-ui-in-business-logic": "error",
+    "fsd/ordered-imports": "error",
+  },
+}
+```
+
+</details>
+
+<details>
+<summary>base 프리셋 설정</summary>
+
+```js
+{
+  plugins: {
+    fsd: fsdPlugin,
+  },
+  rules: {
+    "fsd/forbidden-imports": "warn",
+    "fsd/no-cross-slice-dependency": "warn",
+    "fsd/no-global-store-imports": "error",
+    "fsd/no-public-api-sidestep": "warn",
+    "fsd/no-relative-imports": "off",
+    "fsd/no-ui-in-business-logic": "error",
+    "fsd/ordered-imports": "warn",
+  },
+}
+```
+
+</details>
+
 ### Next.js App Router와 커스텀 레이어 폴더명
 
 Next.js App Router 프로젝트에서는 Next의 라우팅 파일을 `src/app`에 두고, 나머지 코드를 FSD 레이어로 구성할 수 있습니다.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ export default [fsdPlugin.configs.recommended];
 
 ### Strict Preset
 
-Use `strict` when you want all architectural checks to fail the build.
+Use `strict` when you want all architectural checks to fail the build. This
+preset also requires slice-level public API imports and applies public API
+enforcement to `shared`.
 
 ```js
 import fsdPlugin from "eslint-plugin-fsd-lint";

--- a/README.md
+++ b/README.md
@@ -83,6 +83,80 @@ import fsdPlugin from "eslint-plugin-fsd-lint";
 export default [fsdPlugin.configs.base];
 ```
 
+<details>
+<summary>Recommended preset configuration</summary>
+
+```js
+{
+  plugins: {
+    fsd: fsdPlugin,
+  },
+  rules: {
+    "fsd/forbidden-imports": "error",
+    "fsd/no-cross-slice-dependency": "error",
+    "fsd/no-global-store-imports": "error",
+    "fsd/no-public-api-sidestep": "error",
+    "fsd/no-relative-imports": "error",
+    "fsd/no-ui-in-business-logic": "error",
+    "fsd/ordered-imports": "warn",
+  },
+}
+```
+
+</details>
+
+<details>
+<summary>Strict preset configuration</summary>
+
+```js
+{
+  plugins: {
+    fsd: fsdPlugin,
+  },
+  rules: {
+    "fsd/forbidden-imports": "error",
+    "fsd/no-cross-slice-dependency": "error",
+    "fsd/no-global-store-imports": "error",
+    "fsd/no-public-api-sidestep": [
+      "error",
+      {
+        publicApi: {
+          allowSegmentImports: false,
+          enforceShared: true,
+        },
+      },
+    ],
+    "fsd/no-relative-imports": "error",
+    "fsd/no-ui-in-business-logic": "error",
+    "fsd/ordered-imports": "error",
+  },
+}
+```
+
+</details>
+
+<details>
+<summary>Base preset configuration</summary>
+
+```js
+{
+  plugins: {
+    fsd: fsdPlugin,
+  },
+  rules: {
+    "fsd/forbidden-imports": "warn",
+    "fsd/no-cross-slice-dependency": "warn",
+    "fsd/no-global-store-imports": "error",
+    "fsd/no-public-api-sidestep": "warn",
+    "fsd/no-relative-imports": "off",
+    "fsd/no-ui-in-business-logic": "error",
+    "fsd/ordered-imports": "warn",
+  },
+}
+```
+
+</details>
+
 ### Manual Configuration
 
 Use manual configuration when you want fine-grained control over each rule.

--- a/README.md
+++ b/README.md
@@ -417,12 +417,18 @@ For stricter projects, segment-level public API imports can be disabled and the
 `shared` layer can be included in public API enforcement:
 
 ```js
-"fsd/no-public-api-sidestep": [
-  "error",
+export default [
   {
-    publicApi: {
-      allowSegmentImports: false,
-      enforceShared: true,
+    rules: {
+      "fsd/no-public-api-sidestep": [
+        "error",
+        {
+          publicApi: {
+            allowSegmentImports: false,
+            enforceShared: true,
+          },
+        },
+      ],
     },
   },
 ];

--- a/README.md
+++ b/README.md
@@ -413,6 +413,21 @@ import { userModel } from "@entities/user/model";
 import { authSlice } from "@features/auth/model/slice";
 ```
 
+For stricter projects, segment-level public API imports can be disabled and the
+`shared` layer can be included in public API enforcement:
+
+```js
+"fsd/no-public-api-sidestep": [
+  "error",
+  {
+    publicApi: {
+      allowSegmentImports: false,
+      enforceShared: true,
+    },
+  },
+];
+```
+
 ### `fsd/no-cross-slice-dependency`
 
 ```js

--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,15 @@ export const configs = {
       "fsd/forbidden-imports": "error",
       "fsd/no-cross-slice-dependency": "error",
       "fsd/no-global-store-imports": "error",
-      "fsd/no-public-api-sidestep": "error",
+      "fsd/no-public-api-sidestep": [
+        "error",
+        {
+          publicApi: {
+            allowSegmentImports: false,
+            enforceShared: true,
+          },
+        },
+      ],
       "fsd/no-relative-imports": "error",
       "fsd/no-ui-in-business-logic": "error",
       "fsd/ordered-imports": "error",

--- a/src/rules/no-public-api-sidestep.js
+++ b/src/rules/no-public-api-sidestep.js
@@ -5,6 +5,8 @@
 import { mergeConfig } from "../utils/config-utils.js";
 import {
   extractLayerFromImportPath,
+  getImportPathWithoutAlias,
+  isRelativePath,
   isTestFile,
   normalizePath,
 } from "../utils/path-utils.js";
@@ -87,6 +89,16 @@ export default {
                 type: "array",
                 items: { type: "string" },
               },
+              allowSegmentImports: {
+                type: "boolean",
+                description:
+                  "Allow imports from segment-level public API entry points such as @entities/user/model",
+              },
+              enforceShared: {
+                type: "boolean",
+                description:
+                  "Also enforce public API imports for the shared layer",
+              },
             },
             additionalProperties: false,
           },
@@ -123,13 +135,18 @@ export default {
     });
 
     // Layers that require public API
-    const restrictedLayers = Array.isArray(options.layers)
+    const restrictedLayerList = Array.isArray(options.layers)
       ? options.layers
       : config.publicApi?.enforceForLayers || [
           "features",
           "entities",
           "widgets",
         ];
+    const restrictedLayers = new Set(restrictedLayerList);
+
+    if (config.publicApi?.enforceShared) {
+      restrictedLayers.add("shared");
+    }
 
     // Files that are considered public API
     const publicApiFiles = options.publicApiFiles ||
@@ -143,164 +160,156 @@ export default {
     // Allow type imports if configured
     const allowTypeImports = options.allowTypeImports || false;
 
+    const allowSegmentImports = config.publicApi?.allowSegmentImports !== false;
+
+    function isPublicApiFileName(segment) {
+      return publicApiFiles.some((apiFile) => {
+        const fileName = normalizePath(apiFile).split("/").pop();
+        const fileNameWithoutExtension = fileName.replace(/\.[^.]+$/, "");
+
+        return segment === fileName || segment === fileNameWithoutExtension;
+      });
+    }
+
+    function isAllowedSlicePublicApiImport(segments) {
+      // @features/auth
+      if (segments.length === 2) {
+        return true;
+      }
+
+      // @features/auth/index or @features/auth/index.ts
+      if (segments.length === 3 && isPublicApiFileName(segments[2])) {
+        return true;
+      }
+
+      if (!allowSegmentImports) {
+        return false;
+      }
+
+      // @features/auth/model
+      if (segments.length === 3) {
+        return true;
+      }
+
+      // Preserve existing behavior where any configured index file is treated
+      // as a public API entry point.
+      return isPublicApiFileName(segments[segments.length - 1]);
+    }
+
+    function isAllowedSharedPublicApiImport(segments) {
+      // @shared
+      if (segments.length === 1) {
+        return true;
+      }
+
+      // @shared/index or @shared/index.ts
+      if (segments.length === 2 && isPublicApiFileName(segments[1])) {
+        return true;
+      }
+
+      if (!allowSegmentImports) {
+        return false;
+      }
+
+      // @shared/ui
+      if (segments.length === 2) {
+        return true;
+      }
+
+      // Preserve existing behavior for explicit index public API files.
+      return isPublicApiFileName(segments[segments.length - 1]);
+    }
+
+    function isAllowedPublicApiImport(importPath, importLayer) {
+      const pathWithoutAlias = getImportPathWithoutAlias(importPath, config);
+
+      if (!pathWithoutAlias) {
+        return false;
+      }
+
+      const segments = pathWithoutAlias.split("/").filter(Boolean);
+      if (segments.length === 0) {
+        return false;
+      }
+
+      if (importLayer === "shared") {
+        return isAllowedSharedPublicApiImport(segments);
+      }
+
+      return isAllowedSlicePublicApiImport(segments);
+    }
+
+    function checkImport(node, importPath, filePath, { isTypeImport }) {
+      if (typeof importPath !== "string") {
+        return;
+      }
+
+      // Skip test files
+      if (isTestFile(filePath, config.testFilesPatterns)) {
+        return;
+      }
+
+      // Check for ignored patterns
+      const isIgnored = config.ignoreImportPatterns.some((pattern) => {
+        const regex = new RegExp(pattern);
+        return regex.test(importPath);
+      });
+
+      if (isIgnored) {
+        return;
+      }
+
+      // Skip relative imports
+      if (isRelativePath(importPath)) {
+        return;
+      }
+
+      // Skip type-only imports if configured
+      if (allowTypeImports && isTypeImport) {
+        return;
+      }
+
+      // Get layer from import path
+      const importLayer = extractLayerFromImportPath(importPath, config);
+
+      // Skip if not importing from a restricted layer
+      if (!importLayer || !restrictedLayers.has(importLayer)) {
+        return;
+      }
+
+      if (isAllowedPublicApiImport(importPath, importLayer)) {
+        return;
+      }
+
+      context.report({
+        node,
+        messageId: "noDirectImport",
+        data: {
+          importPath,
+        },
+      });
+    }
+
     return {
       ImportDeclaration(node) {
-        const filePath = normalizePath(context.filename);
-        const importPath = node.source.value;
-
-        // Skip test files
-        if (isTestFile(filePath, config.testFilesPatterns)) {
-          return;
-        }
-
-        // Check for ignored patterns
-        const isIgnored = config.ignoreImportPatterns.some((pattern) => {
-          const regex = new RegExp(pattern);
-          return regex.test(importPath);
-        });
-
-        if (isIgnored) {
-          return;
-        }
-
-        // Skip relative imports
-        if (importPath.startsWith(".")) {
-          return;
-        }
-
-        // Skip type-only imports if configured
-        if (allowTypeImports && node.importKind === "type") {
-          return;
-        }
-
-        // Get layer from import path
-        const importLayer = extractLayerFromImportPath(importPath, config);
-
-        // Skip if not importing from a restricted layer
-        if (!importLayer || !restrictedLayers.includes(importLayer)) {
-          return;
-        }
-
-        // Check if it's importing directly from a public API file
-        const normalizedImportPath = normalizePath(importPath);
-        const isPublicApiImport = publicApiFiles.some((apiFile) => {
-          return (
-            normalizedImportPath.endsWith(`/${apiFile}`) ||
-            normalizedImportPath.endsWith(`/${apiFile.replace(".ts", "")}`)
-          );
-        });
-
-        // Also check if it's importing from just the slice (without specific file)
-        // Example: @features/auth vs @features/auth/model/slice
-        const pathParts = normalizedImportPath.split("/");
-        const layerIndex = pathParts.findIndex((part) => {
-          const normalizedPart = normalizePath(part);
-          // Check if the part contains the layer (e.g., @entities contains entities)
-          return (
-            normalizedPart === importLayer ||
-            normalizedPart.includes(importLayer) ||
-            config.layers[importLayer]?.pattern === normalizedPart
-          );
-        });
-
-        // If import only specifies layer and slice, it's considered a public API import
-        const isSliceRootImport =
-          layerIndex >= 0 && pathParts.length === layerIndex + 2;
-
-        // Check if it's importing from a segment level (e.g., @entities/user/model, @entities/user/ui, @entities/user/anySegmentName)
-        // Any segment name is allowed in FSD architecture
-        const isSegmentImport =
-          layerIndex >= 0 && pathParts.length === layerIndex + 3;
-
-        // If either a public API file, slice root, or segment root, it's valid
-        if (isPublicApiImport || isSliceRootImport || isSegmentImport) {
-          return;
-        }
-
-        context.report({
-          node,
-          messageId: "noDirectImport",
-          data: {
-            importPath,
-          },
+        checkImport(node, node.source.value, normalizePath(context.filename), {
+          isTypeImport: node.importKind === "type",
         });
       },
       CallExpression(node) {
-        // Handle dynamic imports
         if (node.callee.type === "Import") {
-          const importPath = node.arguments[0].value;
-
-          // Skip relative imports
-          if (importPath.startsWith(".")) {
-            return;
-          }
-
-          // Skip test files
-          if (isTestFile(context.filename, config.testFilesPatterns)) {
-            return;
-          }
-
-          // Check for ignored patterns
-          const isIgnored = config.ignoreImportPatterns.some((pattern) => {
-            const regex = new RegExp(pattern);
-            return regex.test(importPath);
-          });
-
-          if (isIgnored) {
-            return;
-          }
-
-          // Get layer from import path
-          const importLayer = extractLayerFromImportPath(importPath, config);
-
-          // Skip if not importing from a restricted layer
-          if (!importLayer || !restrictedLayers.includes(importLayer)) {
-            return;
-          }
-
-          // Check if it's importing directly from a public API file
-          const normalizedImportPath = normalizePath(importPath);
-          const isPublicApiImport = publicApiFiles.some((apiFile) => {
-            return (
-              normalizedImportPath.endsWith(`/${apiFile}`) ||
-              normalizedImportPath.endsWith(`/${apiFile.replace(".ts", "")}`)
-            );
-          });
-
-          // Also check if it's importing from just the slice (without specific file)
-          const pathParts = normalizedImportPath.split("/");
-          const layerIndex = pathParts.findIndex((part) => {
-            const normalizedPart = normalizePath(part);
-            // Check if the part contains the layer (e.g., @entities contains entities)
-            return (
-              normalizedPart === importLayer ||
-              normalizedPart.includes(importLayer) ||
-              config.layers[importLayer]?.pattern === normalizedPart
-            );
-          });
-
-          // If import only specifies layer and slice, it's considered a public API import
-          const isSliceRootImport =
-            layerIndex >= 0 && pathParts.length === layerIndex + 2;
-
-          // Check if it's importing from a segment level (e.g., @entities/user/model, @entities/user/ui, @entities/user/anySegmentName)
-          // Any segment name is allowed in FSD architecture
-          const isSegmentImport =
-            layerIndex >= 0 && pathParts.length === layerIndex + 3;
-
-          // If either a public API file, slice root, or segment root, it's valid
-          if (isPublicApiImport || isSliceRootImport || isSegmentImport) {
-            return;
-          }
-
-          context.report({
+          checkImport(
             node,
-            messageId: "noDirectImport",
-            data: {
-              importPath,
-            },
-          });
+            node.arguments[0]?.value,
+            normalizePath(context.filename),
+            { isTypeImport: false },
+          );
         }
+      },
+      ImportExpression(node) {
+        checkImport(node, node.source?.value, normalizePath(context.filename), {
+          isTypeImport: false,
+        });
       },
     };
   },

--- a/src/utils/config-utils.js
+++ b/src/utils/config-utils.js
@@ -70,6 +70,8 @@ export const defaultConfig = {
   publicApi: {
     enforceForLayers: ["features", "entities", "widgets"],
     fileNames: ["index.ts", "index.tsx", "index.js", "index.jsx"],
+    allowSegmentImports: true,
+    enforceShared: false,
   },
 
   // Exception handling settings

--- a/tests/configs.test.js
+++ b/tests/configs.test.js
@@ -48,6 +48,28 @@ describe("preset configs", () => {
     expect(messages[0].severity).toBe(2);
   });
 
+  it("strict preset requires slice-level public API imports", async () => {
+    const messages = await lintWithConfig(
+      fsdPlugin.configs.strict,
+      'import { userModel } from "@entities/user/model";',
+    );
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0].ruleId).toBe("fsd/no-public-api-sidestep");
+    expect(messages[0].severity).toBe(2);
+  });
+
+  it("strict preset enforces public API imports for shared", async () => {
+    const messages = await lintWithConfig(
+      fsdPlugin.configs.strict,
+      'import { Button } from "@shared/ui/Button";',
+    );
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0].ruleId).toBe("fsd/no-public-api-sidestep");
+    expect(messages[0].severity).toBe(2);
+  });
+
   it("base preset downgrades forbidden-imports to a warning", async () => {
     const messages = await lintWithConfig(
       fsdPlugin.configs.base,

--- a/tests/no-public-api-sidestep-options.test.js
+++ b/tests/no-public-api-sidestep-options.test.js
@@ -1,0 +1,143 @@
+import { ESLint } from "eslint";
+import tsParser from "@typescript-eslint/parser";
+import { describe, expect, it } from "vitest";
+
+import fsdPlugin from "../src/index.js";
+
+function createEslint(ruleOptions = {}) {
+  return new ESLint({
+    overrideConfigFile: true,
+    ignore: false,
+    overrideConfig: [
+      {
+        files: ["**/*.ts", "**/*.tsx"],
+        languageOptions: {
+          parser: tsParser,
+          ecmaVersion: 2022,
+          sourceType: "module",
+        },
+        plugins: {
+          fsd: fsdPlugin,
+        },
+        rules: {
+          "fsd/no-public-api-sidestep": ["error", ruleOptions],
+        },
+      },
+    ],
+  });
+}
+
+async function lintText(code, ruleOptions) {
+  const eslint = createEslint(ruleOptions);
+  const [result] = await eslint.lintText(code, {
+    filePath: "src/features/profile/model/profile.ts",
+  });
+
+  return result.messages;
+}
+
+function getMessageIds(messages) {
+  return messages.map((message) => message.messageId);
+}
+
+describe("no-public-api-sidestep publicApi options", () => {
+  it("keeps segment-level public API imports allowed by default", async () => {
+    const messages = await lintText(
+      `
+        import { userModel } from "@entities/user/model";
+        import { userUi } from "@entities/user/ui";
+      `,
+    );
+
+    expect(messages).toEqual([]);
+  });
+
+  it("can require slice-level public API imports only", async () => {
+    const messages = await lintText(
+      `
+        import { User } from "@entities/user";
+        import { UserIndex } from "@entities/user/index";
+        import { userModel } from "@entities/user/model";
+        import { userModelIndex } from "@entities/user/model/index";
+      `,
+      {
+        publicApi: {
+          allowSegmentImports: false,
+        },
+      },
+    );
+
+    expect(getMessageIds(messages)).toEqual([
+      "noDirectImport",
+      "noDirectImport",
+    ]);
+  });
+
+  it("keeps shared unrestricted by default", async () => {
+    const messages = await lintText(
+      `
+        import { Button } from "@shared/ui/Button";
+        import { formatDate } from "@shared/lib/date";
+      `,
+    );
+
+    expect(messages).toEqual([]);
+  });
+
+  it("can enforce public API imports for shared", async () => {
+    const messages = await lintText(
+      `
+        import { SharedUi } from "@shared/ui";
+        import { Button } from "@shared/ui/Button";
+        import { formatDate } from "@shared/lib/date";
+      `,
+      {
+        publicApi: {
+          enforceShared: true,
+        },
+      },
+    );
+
+    expect(getMessageIds(messages)).toEqual([
+      "noDirectImport",
+      "noDirectImport",
+    ]);
+  });
+
+  it("can require root public API imports for shared", async () => {
+    const messages = await lintText(
+      `
+        import { sharedApi } from "@shared";
+        import { sharedIndex } from "@shared/index";
+        import { SharedUi } from "@shared/ui";
+      `,
+      {
+        publicApi: {
+          enforceShared: true,
+          allowSegmentImports: false,
+        },
+      },
+    );
+
+    expect(getMessageIds(messages)).toEqual(["noDirectImport"]);
+  });
+
+  it("reports dynamic import expressions with the same public API options", async () => {
+    const messages = await lintText(
+      'const userModel = await import("@entities/user/model");',
+      {
+        publicApi: {
+          allowSegmentImports: false,
+        },
+      },
+    );
+
+    expect(getMessageIds(messages)).toEqual(["noDirectImport"]);
+  });
+
+  it("ignores nonliteral dynamic import expressions", async () => {
+    const messages = await lintText("const module = await import(modulePath);");
+
+    expect(messages).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Description
Adds configurable strictness options for `fsd/no-public-api-sidestep` while preserving the existing default behavior.

## Changes
- Added `publicApi.allowSegmentImports` with a default of `true` so segment-level public API imports remain allowed by default.
- Added `publicApi.enforceShared` with a default of `false` so the `shared` layer remains unrestricted unless explicitly enabled.
- Refactored static and dynamic import handling through shared public API validation logic.
- Added coverage for default behavior, strict slice-level public API enforcement, shared enforcement, and dynamic import handling.
- Documented the new options in both English and Korean README files.

## Before / After
| Case | Before | After |
| --- | --- | --- |
| `@entities/user/model` | Allowed | Allowed by default; forbidden with `publicApi.allowSegmentImports: false` |
| `@shared/ui/Button` | Allowed | Allowed by default; checked when `publicApi.enforceShared: true` |
| Existing default config | Segment imports allowed, shared unrestricted | Same behavior |

## Type of Change
- [x] Documentation
- [ ] Bug fix
- [x] Feature
- [x] Refactoring
- [ ] Other (describe below)

## How to Test
- `npm test`
- `npm run lint`
- `npm run format:check`

## Additional Information
The new options are opt-in and default to the previous rule behavior.
