### PR TITLE
feat: resolve aliased imports against tsconfig before applying FSD rules

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -23,6 +23,7 @@
 - **크로스 플랫폼 호환성**: Windows와 Unix 기반 시스템 모두에서 원활하게 작동
 - **유연한 폴더 이름 지정**: 사용자 정의 폴더 이름 패턴(`1_app`, `2_pages` 등) 지원
 - **다양한 별칭 형식**: `@shared`와 `@/shared` 모두 지원
+- **tsconfig 경로 인식**: `tsconfig.json` / `jsconfig.json`의 `paths`와 `baseUrl`을 사용해 alias가 가리키는 실제 파일을 기준으로 레이어와 슬라이스를 판별
 - **포괄적인 테스트 커버리지**: 실제 시나리오와 엣지 케이스로 철저히 테스트됨
 
 ### 🔍 Feature-Sliced Design이란?
@@ -290,6 +291,63 @@ src/
 
 `allowedToImport`, `excludeLayers`, `publicApi.enforceForLayers`, `ordered-imports.customOrder` 같은 옵션은 여전히 표준 레이어 키(`app`, `pages`, `widgets`, `features`, `entities`, `shared`)를 사용합니다. `pattern` 값만 실제 폴더명이나 import segment로 쓰입니다.
 새 프로젝트라면 명확한 이유가 없는 한 표준 레이어 폴더명을 우선 사용하는 편이 좋습니다.
+
+### 파일시스템 기반 import 해석
+
+레이어와 슬라이스는 더 이상 import 문자열이 아니라 실제 해석된 파일 경로를 기준으로 판단합니다. 각 규칙은 다음 순서로 import를 해석합니다.
+
+1. `tsconfig.json` / `jsconfig.json`의 `paths` (가장 긴 패턴이 우선, 다중 타겟은 디스크에 존재하는 첫 번째 파일을 선택)
+2. `tsconfig.json`의 `baseUrl`
+3. 설정된 FSD `alias`와 `rootPath` 조합
+4. 현재 파일 기준 상대 경로
+5. 실제 파일을 찾지 못했을 때의 legacy 문자열 파싱 (예: 번들러에만 alias가 정의된 경우)
+
+이 변경 덕분에 alias로 작성한 같은 슬라이스 import가 더 이상 cross-slice로 잘못 보고되지 않습니다. 예를 들어 `tsconfig.json`이 `@articles/*`를 `src/pages/articles/*`로 매핑하고 있다면, 아래 코드는 이제 정상으로 통과합니다.
+
+```ts
+// src/pages/articles/ui/articles-pending-page.tsx
+import { articleSections } from "@articles/api/queries";
+import { ArticlesLayout } from "@articles/ui/articles-page";
+```
+
+기본적으로는 린트 대상 파일에서 위로 올라가며 가장 가까운 `tsconfig.json` / `jsconfig.json`을 자동으로 찾습니다. 원하는 설정 파일이 다른 경로에 있다면 각 규칙에 `tsconfigPath`로 지정할 수 있습니다.
+
+```js
+import fsdPlugin from "eslint-plugin-fsd-lint";
+
+export default [
+  {
+    plugins: {
+      fsd: fsdPlugin,
+    },
+    rules: {
+      "fsd/forbidden-imports": [
+        "error",
+        {
+          rootPath: "/apps/web/src/",
+          tsconfigPath: "./apps/web/tsconfig.json",
+        },
+      ],
+      "fsd/no-cross-slice-dependency": [
+        "error",
+        {
+          rootPath: "/apps/web/src/",
+          tsconfigPath: "./apps/web/tsconfig.json",
+        },
+      ],
+      "fsd/no-public-api-sidestep": [
+        "error",
+        {
+          rootPath: "/apps/web/src/",
+          tsconfigPath: "./apps/web/tsconfig.json",
+        },
+      ],
+    },
+  },
+];
+```
+
+타겟 파일을 찾지 못하면 자동으로 legacy 문자열 파싱으로 폴백되므로, 번들러에만 alias가 정의된 프로젝트는 기존과 동일하게 동작합니다.
 
 ### 🛠️ 고급 구성
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ It is built for modern ESLint setups and works with:
 - JavaScript and TypeScript projects
 - Windows and Unix-style paths
 - both `@shared/...` and `@/shared/...` aliases
+- `tsconfig.json` / `jsconfig.json` `paths` and `baseUrl` mappings
 - custom folder naming like `1_app`, `2_pages`, `5_features`
 - custom source roots through `rootPath`
 
@@ -199,13 +200,14 @@ export default [
 
 Several rules support the same core options.
 
-| Option                 | Purpose                                                                                                    | Example                                                         |
-| ---------------------- | ---------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
-| `alias`                | Defines the import alias format for your project.                                                          | `{ value: '@', withSlash: false }`                              |
-| `rootPath`             | Tells the plugin where the FSD tree starts in the absolute file path. Useful for monorepos or nested apps. | `'/apps/web/src/'`                                              |
-| `folderPattern`        | Supports numbered or customized layer directory names.                                                     | `{ enabled: true, regex: '^(\\d+_)?(.*)', extractionGroup: 2 }` |
-| `testFilesPatterns`    | Allows test files to bypass specific architectural rules.                                                  | `['**/*.test.*', '**/*.spec.*']`                                |
-| `ignoreImportPatterns` | Skips selected import paths for a rule.                                                                    | `['/types$', '^virtual:']`                                      |
+| Option                 | Purpose                                                                                                                                             | Example                                                         |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| `alias`                | Defines the import alias format for your project.                                                                                                   | `{ value: '@', withSlash: false }`                              |
+| `rootPath`             | Tells the plugin where the FSD tree starts in the absolute file path. Useful for monorepos or nested apps.                                          | `'/apps/web/src/'`                                              |
+| `tsconfigPath`         | Points the resolver at a specific `tsconfig.json` / `jsconfig.json`. Optional — when omitted, the plugin walks up from the linted file to find one. | `'./tsconfig.json'`                                             |
+| `folderPattern`        | Supports numbered or customized layer directory names.                                                                                              | `{ enabled: true, regex: '^(\\d+_)?(.*)', extractionGroup: 2 }` |
+| `testFilesPatterns`    | Allows test files to bypass specific architectural rules.                                                                                           | `['**/*.test.*', '**/*.spec.*']`                                |
+| `ignoreImportPatterns` | Skips selected import paths for a rule.                                                                                                             | `['/types$', '^virtual:']`                                      |
 
 ### `rootPath` Example
 
@@ -242,6 +244,63 @@ Typical `rootPath` values:
 - `'/src/root/'`
 
 The value should match a stable segment inside the absolute path ESLint sees for your files.
+
+### Filesystem-aware Import Resolution
+
+Layer and slice information is now derived from the resolved file path, not from the literal text of an import. Each rule resolves an import in this order:
+
+1. `tsconfig.json` / `jsconfig.json` `paths` (longest pattern wins, multiple targets fall through until one exists on disk)
+2. `tsconfig.json` `baseUrl`
+3. The configured FSD `alias` against `rootPath`
+4. Relative path resolution against the importing file
+5. Legacy string parsing (used when no real file can be resolved, for example when an alias is declared in a bundler config but not in `tsconfig.json`)
+
+This is what closes the same-slice false positives that previously appeared with aliased imports. For example, given a `tsconfig.json` that maps `@articles/*` to `src/pages/articles/*`, the following stays inside the `articles` slice and is no longer reported:
+
+```ts
+// src/pages/articles/ui/articles-pending-page.tsx
+import { articleSections } from "@articles/api/queries";
+import { ArticlesLayout } from "@articles/ui/articles-page";
+```
+
+By default the resolver walks upward from the linted file looking for `tsconfig.json` or `jsconfig.json`. When that is not the file you want, point each rule at an explicit one with `tsconfigPath`:
+
+```js
+import fsdPlugin from "eslint-plugin-fsd-lint";
+
+export default [
+  {
+    plugins: {
+      fsd: fsdPlugin,
+    },
+    rules: {
+      "fsd/forbidden-imports": [
+        "error",
+        {
+          rootPath: "/apps/web/src/",
+          tsconfigPath: "./apps/web/tsconfig.json",
+        },
+      ],
+      "fsd/no-cross-slice-dependency": [
+        "error",
+        {
+          rootPath: "/apps/web/src/",
+          tsconfigPath: "./apps/web/tsconfig.json",
+        },
+      ],
+      "fsd/no-public-api-sidestep": [
+        "error",
+        {
+          rootPath: "/apps/web/src/",
+          tsconfigPath: "./apps/web/tsconfig.json",
+        },
+      ],
+    },
+  },
+];
+```
+
+Resolution falls back to legacy string parsing whenever a target file cannot be located, so projects that rely on bundler-only aliases continue to work as before.
 
 ### Next.js App Router and Custom Layer Folder Names
 

--- a/src/rules/forbidden-imports.js
+++ b/src/rules/forbidden-imports.js
@@ -4,8 +4,10 @@
 
 import { mergeConfig } from "../utils/config-utils.js";
 import {
-  extractLayerFromImportPath,
   extractLayerFromPath,
+  extractSliceFromPath,
+  getEntityCrossImportPublicApiInfo,
+  getImportTargetInfo,
   isTestFile,
   normalizePath,
 } from "../utils/path-utils.js";
@@ -27,6 +29,7 @@ export default {
         type: "object",
         properties: {
           rootPath: { type: "string" },
+          tsconfigPath: { type: "string" },
           alias: {
             oneOf: [
               { type: "string" },
@@ -83,6 +86,7 @@ export default {
     // Merge user config with default config
     const options = context.options[0] || {};
     const config = mergeConfig(options);
+    const singleLayerModules = new Set(["app", "shared"]);
 
     return {
       ImportDeclaration(node) {
@@ -107,12 +111,42 @@ export default {
         // Extract current file's layer
         const fromLayer = extractLayerFromPath(filePath, config);
 
-        // Extract import path's layer
-        const toLayer = extractLayerFromImportPath(importPath, config);
+        // Extract import target info, resolving aliases to filesystem paths when possible.
+        const target = getImportTargetInfo(importPath, filePath, config);
+        const toLayer = target.layer;
 
         // Cannot determine layers (external libraries, etc.)
         if (!fromLayer || !toLayer) {
           return;
+        }
+
+        // Same-slice imports are internal implementation details, even when
+        // written through an alias such as "@/pages/articles/...".
+        if (fromLayer === toLayer) {
+          if (singleLayerModules.has(fromLayer)) {
+            return;
+          }
+
+          const fromSlice = extractSliceFromPath(filePath, config);
+          const toSlice = target.slice;
+
+          if (fromSlice && toSlice && fromSlice === toSlice) {
+            return;
+          }
+
+          const crossImportInfo = getEntityCrossImportPublicApiInfo(
+            importPath,
+            filePath,
+            config,
+          );
+
+          if (
+            crossImportInfo &&
+            fromLayer === "entities" &&
+            fromSlice === crossImportInfo.consumerSlice
+          ) {
+            return;
+          }
         }
 
         // Get layer priorities and allowed imports

--- a/src/rules/no-cross-slice-dependency.js
+++ b/src/rules/no-cross-slice-dependency.js
@@ -2,14 +2,12 @@
  * @fileoverview Prevents direct dependencies between slices in the same layer. Each slice should be isolated.
  */
 
-import path from "path";
 import { mergeConfig } from "../utils/config-utils.js";
 import {
-  extractLayerFromImportPath,
   extractLayerFromPath,
-  extractSliceFromImportPath,
   extractSliceFromPath,
-  isRelativePath,
+  getEntityCrossImportPublicApiInfo,
+  getImportTargetInfo,
   isTestFile,
   normalizePath,
 } from "../utils/path-utils.js";
@@ -33,6 +31,7 @@ export default {
         type: "object",
         properties: {
           rootPath: { type: "string" },
+          tsconfigPath: { type: "string" },
           alias: {
             oneOf: [
               { type: "string" },
@@ -202,42 +201,32 @@ export default {
         return;
       }
 
-      // Handle relative paths by checking if they go outside the slice
-      if (isRelativePath(importPath)) {
-        const currentDir = path.posix.dirname(filePath);
-        const resolvedImportPath = normalizePath(
-          path.posix.join(currentDir, importPath),
-        );
-        const toLayer = extractLayerFromPath(resolvedImportPath, config);
-
-        if (toLayer !== fromLayer) {
-          return;
-        }
-
-        const toSlice = extractSliceFromPath(resolvedImportPath, config);
-
-        if (!toSlice || toSlice === fromSlice) {
-          return;
-        }
-
-        if (shouldReportSlicePair(fromLayer, fromSlice, toLayer, toSlice)) {
-          reportSliceViolation(node, fromLayer, fromSlice, toSlice);
-        }
-        return;
-      }
-
-      // For absolute imports, check if it's importing from the same layer but different slice
-      const toLayer = extractLayerFromImportPath(importPath, config);
+      const target = getImportTargetInfo(importPath, filePath, config);
+      const toLayer = target.layer;
 
       // Only check imports within the same layer
       if (toLayer !== fromLayer) {
         return;
       }
 
-      const toSlice = extractSliceFromImportPath(importPath, config);
+      const toSlice = target.slice;
 
       // Skip if slice info is missing or same slice
       if (!toSlice || toSlice === fromSlice) {
+        return;
+      }
+
+      const crossImportInfo = getEntityCrossImportPublicApiInfo(
+        importPath,
+        filePath,
+        config,
+      );
+
+      if (
+        crossImportInfo &&
+        fromLayer === "entities" &&
+        fromSlice === crossImportInfo.consumerSlice
+      ) {
         return;
       }
 

--- a/src/rules/no-public-api-sidestep.js
+++ b/src/rules/no-public-api-sidestep.js
@@ -4,7 +4,12 @@
 
 import { mergeConfig } from "../utils/config-utils.js";
 import {
-  extractLayerFromImportPath,
+  extractLayerFromPath,
+  extractSliceFromPath,
+  findLayerBySegment,
+  getEntityCrossImportPublicApiInfo,
+  getImportTargetInfo,
+  getRelativePathFromRoot,
   getImportPathWithoutAlias,
   isRelativePath,
   isTestFile,
@@ -69,6 +74,7 @@ export default {
             ],
           },
           rootPath: { type: "string" },
+          tsconfigPath: { type: "string" },
           folderPattern: {
             type: "object",
             properties: {
@@ -232,11 +238,69 @@ export default {
         return false;
       }
 
+      if (findLayerBySegment(segments[0], config) !== importLayer) {
+        return false;
+      }
+
       if (importLayer === "shared") {
         return isAllowedSharedPublicApiImport(segments);
       }
 
       return isAllowedSlicePublicApiImport(segments);
+    }
+
+    function isAllowedResolvedPublicApiImport(resolvedPath, importLayer) {
+      const relativePath = getRelativePathFromRoot(
+        resolvedPath,
+        config.rootPath,
+      );
+      if (!relativePath) {
+        return false;
+      }
+
+      const segments = relativePath.split("/").filter(Boolean);
+      if (segments.length === 0) {
+        return false;
+      }
+
+      if (importLayer === "shared") {
+        if (segments.length === 2 && isPublicApiFileName(segments[1])) {
+          return true;
+        }
+
+        return (
+          allowSegmentImports &&
+          segments.length >= 3 &&
+          isPublicApiFileName(segments[segments.length - 1])
+        );
+      }
+
+      if (segments.length === 3 && isPublicApiFileName(segments[2])) {
+        return true;
+      }
+
+      return (
+        allowSegmentImports &&
+        segments.length === 4 &&
+        isPublicApiFileName(segments[3])
+      );
+    }
+
+    function isAllowedEntityCrossImport(importPath, filePath, importLayer) {
+      const crossImportInfo = getEntityCrossImportPublicApiInfo(
+        importPath,
+        filePath,
+        config,
+      );
+
+      if (!crossImportInfo || importLayer !== "entities") {
+        return false;
+      }
+
+      return (
+        extractLayerFromPath(filePath, config) === "entities" &&
+        extractSliceFromPath(filePath, config) === crossImportInfo.consumerSlice
+      );
     }
 
     function checkImport(node, importPath, filePath, { isTypeImport }) {
@@ -269,15 +333,30 @@ export default {
         return;
       }
 
-      // Get layer from import path
-      const importLayer = extractLayerFromImportPath(importPath, config);
+      const target = getImportTargetInfo(importPath, filePath, config);
+      const importLayer = target.layer;
 
       // Skip if not importing from a restricted layer
       if (!importLayer || !restrictedLayers.has(importLayer)) {
         return;
       }
 
-      if (isAllowedPublicApiImport(importPath, importLayer)) {
+      const currentLayer = extractLayerFromPath(filePath, config);
+      if (currentLayer === importLayer) {
+        const currentSlice = extractSliceFromPath(filePath, config);
+        const importSlice = target.slice;
+
+        if (currentSlice && importSlice && currentSlice === importSlice) {
+          return;
+        }
+      }
+
+      if (
+        isAllowedEntityCrossImport(importPath, filePath, importLayer) ||
+        (target.resolvedPath &&
+          isAllowedResolvedPublicApiImport(target.resolvedPath, importLayer)) ||
+        isAllowedPublicApiImport(importPath, importLayer)
+      ) {
         return;
       }
 

--- a/src/rules/no-relative-imports.js
+++ b/src/rules/no-relative-imports.js
@@ -30,6 +30,7 @@ export default {
         type: "object",
         properties: {
           rootPath: { type: "string" },
+          tsconfigPath: { type: "string" },
           alias: {
             oneOf: [
               { type: "string" },

--- a/src/rules/no-ui-in-business-logic.js
+++ b/src/rules/no-ui-in-business-logic.js
@@ -26,6 +26,7 @@ export default {
         type: "object",
         properties: {
           rootPath: { type: "string" },
+          tsconfigPath: { type: "string" },
           alias: {
             oneOf: [
               { type: "string" },

--- a/src/rules/ordered-imports.js
+++ b/src/rules/ordered-imports.js
@@ -3,7 +3,7 @@
  */
 
 import { mergeConfig } from "../utils/config-utils.js";
-import { extractLayerFromImportPath } from "../utils/path-utils.js";
+import { getImportTargetInfo, normalizePath } from "../utils/path-utils.js";
 
 export default {
   meta: {
@@ -43,6 +43,7 @@ export default {
               "Custom layer order (default from top to bottom: app, processes, pages, widgets, features, entities, shared)",
           },
           rootPath: { type: "string" },
+          tsconfigPath: { type: "string" },
           layers: {
             type: "object",
             additionalProperties: {
@@ -172,7 +173,11 @@ export default {
           const combinedText = precedingText + importText;
 
           // Classify imports based on FSD layers
-          const layer = extractLayerFromImportPath(importPath, config);
+          const layer = getImportTargetInfo(
+            importPath,
+            normalizePath(context.filename),
+            config,
+          ).layer;
 
           if (layer && layerOrder.includes(layer)) {
             groupedImports[layer].push({

--- a/src/utils/config-utils.js
+++ b/src/utils/config-utils.js
@@ -13,6 +13,10 @@ export const defaultConfig = {
   // Default root path
   rootPath: "/src/",
 
+  // Optional tsconfig/jsconfig path for filesystem-based import resolution.
+  // When omitted, rules search upward from the linted file.
+  tsconfigPath: null,
+
   // Layer definitions and priorities
   layers: {
     app: {
@@ -156,11 +160,14 @@ export function mergeConfig(userConfig = {}) {
   // Merge root path
   const rootPath = userConfig.rootPath || defaultConfig.rootPath;
 
+  const tsconfigPath = userConfig.tsconfigPath || defaultConfig.tsconfigPath;
+
   // Return final configuration
   return {
     alias,
     layers,
     rootPath,
+    tsconfigPath,
     folderPattern,
     testFilesPatterns,
     publicApi,

--- a/src/utils/path-utils.js
+++ b/src/utils/path-utils.js
@@ -2,8 +2,25 @@
  * @fileoverview Path processing utility functions
  */
 
+import fs from "fs";
+import path from "path";
+
 // Path cache
 const pathCache = new Map();
+const tsConfigCache = new Map();
+const importResolveCache = new Map();
+
+const DEFAULT_RESOLVE_EXTENSIONS = [
+  ".ts",
+  ".tsx",
+  ".js",
+  ".jsx",
+  ".mts",
+  ".cts",
+  ".mjs",
+  ".cjs",
+  ".json",
+];
 
 /**
  * Normalize file path (compatible with all operating systems)
@@ -55,6 +72,16 @@ export function isRelativePath(filePath) {
   );
 }
 
+function toAbsolutePath(filePath) {
+  const normalizedPath = normalizePath(filePath);
+
+  if (path.isAbsolute(normalizedPath) || /^[A-Za-z]:\//.test(normalizedPath)) {
+    return normalizedPath;
+  }
+
+  return normalizePath(path.resolve(normalizedPath));
+}
+
 /**
  * Extract relative path from source root
  * @param {string} filePath - File path
@@ -68,6 +95,20 @@ export function getRelativePathFromRoot(filePath, rootPattern = "/src/") {
   if (rootIndex === -1) return null;
 
   return normalizedPath.substring(rootIndex + rootPattern.length);
+}
+
+function getSourceRootFromPath(filePath, rootPattern = "/src/") {
+  const normalizedPath = normalizePath(filePath);
+  const normalizedRootPattern = normalizePath(rootPattern);
+  const rootIndex = normalizedPath.indexOf(normalizedRootPattern);
+
+  if (rootIndex !== -1) {
+    return normalizePath(
+      normalizedPath.substring(0, rootIndex + normalizedRootPattern.length),
+    );
+  }
+
+  return null;
 }
 
 /**
@@ -215,6 +256,374 @@ export function extractSliceFromPath(filePath, config) {
 
   // Second segment is typically the slice
   return segments[1];
+}
+
+function fileExists(filePath) {
+  try {
+    return fs.statSync(filePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function directoryExists(filePath) {
+  try {
+    return fs.statSync(filePath).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function resolveFileCandidate(candidatePath) {
+  const normalizedCandidate = normalizePath(candidatePath);
+
+  if (fileExists(normalizedCandidate)) {
+    return normalizedCandidate;
+  }
+
+  if (!path.extname(normalizedCandidate)) {
+    for (const extension of DEFAULT_RESOLVE_EXTENSIONS) {
+      const withExtension = `${normalizedCandidate}${extension}`;
+      if (fileExists(withExtension)) {
+        return normalizePath(withExtension);
+      }
+    }
+  }
+
+  if (directoryExists(normalizedCandidate)) {
+    for (const extension of DEFAULT_RESOLVE_EXTENSIONS) {
+      const indexPath = path.join(normalizedCandidate, `index${extension}`);
+      if (fileExists(indexPath)) {
+        return normalizePath(indexPath);
+      }
+    }
+  }
+
+  for (const extension of DEFAULT_RESOLVE_EXTENSIONS) {
+    const indexPath = path.join(normalizedCandidate, `index${extension}`);
+    if (fileExists(indexPath)) {
+      return normalizePath(indexPath);
+    }
+  }
+
+  return null;
+}
+
+function stripJsonComments(json) {
+  let result = "";
+  let inString = false;
+  let escaped = false;
+
+  for (let index = 0; index < json.length; index++) {
+    const char = json[index];
+    const next = json[index + 1];
+
+    if (inString) {
+      result += char;
+
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+
+      continue;
+    }
+
+    if (char === '"') {
+      inString = true;
+      result += char;
+      continue;
+    }
+
+    if (char === "/" && next === "/") {
+      while (index < json.length && json[index] !== "\n") {
+        index++;
+      }
+      result += "\n";
+      continue;
+    }
+
+    if (char === "/" && next === "*") {
+      index += 2;
+      while (
+        index < json.length &&
+        !(json[index] === "*" && json[index + 1] === "/")
+      ) {
+        index++;
+      }
+      index++;
+      continue;
+    }
+
+    result += char;
+  }
+
+  return result.replace(/,\s*([}\]])/g, "$1");
+}
+
+function parseTsConfig(tsConfigPath) {
+  const normalizedPath = normalizePath(tsConfigPath);
+
+  if (tsConfigCache.has(normalizedPath)) {
+    return tsConfigCache.get(normalizedPath);
+  }
+
+  let parsedConfig = null;
+
+  try {
+    const rawConfig = fs.readFileSync(normalizedPath, "utf8");
+    const config = JSON.parse(stripJsonComments(rawConfig));
+    const compilerOptions = config.compilerOptions || {};
+    const configDir = normalizePath(path.dirname(normalizedPath));
+    const baseUrl = compilerOptions.baseUrl
+      ? normalizePath(path.resolve(configDir, compilerOptions.baseUrl))
+      : configDir;
+
+    parsedConfig = {
+      path: normalizedPath,
+      dir: configDir,
+      baseUrl,
+      paths: compilerOptions.paths || {},
+    };
+  } catch {
+    parsedConfig = null;
+  }
+
+  tsConfigCache.set(normalizedPath, parsedConfig);
+  return parsedConfig;
+}
+
+function findNearestTsConfig(currentFilePath, config) {
+  if (config.tsconfigPath) {
+    const explicitPath = normalizePath(path.resolve(config.tsconfigPath));
+    return fileExists(explicitPath) ? explicitPath : null;
+  }
+
+  let currentDir = path.dirname(toAbsolutePath(currentFilePath));
+
+  while (currentDir && currentDir !== path.dirname(currentDir)) {
+    for (const configFileName of ["tsconfig.json", "jsconfig.json"]) {
+      const candidatePath = path.join(currentDir, configFileName);
+      if (fileExists(candidatePath)) {
+        return normalizePath(candidatePath);
+      }
+    }
+
+    currentDir = path.dirname(currentDir);
+  }
+
+  return null;
+}
+
+function matchTsConfigPathPattern(importPath, pattern) {
+  if (!pattern.includes("*")) {
+    return importPath === pattern ? "" : null;
+  }
+
+  const [prefix, suffix] = pattern.split("*");
+
+  if (!importPath.startsWith(prefix) || !importPath.endsWith(suffix)) {
+    return null;
+  }
+
+  return importPath.slice(prefix.length, importPath.length - suffix.length);
+}
+
+function resolveWithTsConfigPaths(importPath, currentFilePath, config) {
+  const tsConfigPath = findNearestTsConfig(currentFilePath, config);
+  if (!tsConfigPath) {
+    return null;
+  }
+
+  const tsConfig = parseTsConfig(tsConfigPath);
+  if (!tsConfig) {
+    return null;
+  }
+
+  const pathEntries = Object.entries(tsConfig.paths).sort(
+    ([leftPattern], [rightPattern]) =>
+      rightPattern.replace("*", "").length -
+      leftPattern.replace("*", "").length,
+  );
+
+  for (const [pattern, targets] of pathEntries) {
+    const wildcardMatch = matchTsConfigPathPattern(importPath, pattern);
+    if (wildcardMatch === null) {
+      continue;
+    }
+
+    for (const target of targets) {
+      const mappedTarget = target.includes("*")
+        ? target.replace("*", wildcardMatch)
+        : target;
+      const candidatePath = path.resolve(tsConfig.baseUrl, mappedTarget);
+      const resolvedPath = resolveFileCandidate(candidatePath);
+
+      if (resolvedPath) {
+        return resolvedPath;
+      }
+    }
+  }
+
+  const baseUrlCandidate = path.resolve(tsConfig.baseUrl, importPath);
+  return resolveFileCandidate(baseUrlCandidate);
+}
+
+function resolveWithConfiguredAlias(importPath, currentFilePath, config) {
+  const pathWithoutAlias = getImportPathWithoutAlias(importPath, config);
+
+  if (!pathWithoutAlias) {
+    return null;
+  }
+
+  const sourceRoot = getSourceRootFromPath(
+    toAbsolutePath(currentFilePath),
+    config.rootPath,
+  );
+
+  if (!sourceRoot) {
+    return null;
+  }
+
+  return resolveFileCandidate(path.join(sourceRoot, pathWithoutAlias));
+}
+
+/**
+ * Resolve an import path to a real file when possible.
+ * Falls back to null for external packages or unresolved virtual paths.
+ * @param {string} importPath - Path from import statement
+ * @param {string} currentFilePath - File that contains the import
+ * @param {Object} config - Configuration options
+ * @return {string|null} - Resolved filesystem path or null
+ */
+export function resolveImportPath(importPath, currentFilePath, config) {
+  if (typeof importPath !== "string") {
+    return null;
+  }
+
+  const cacheKey = [
+    importPath,
+    currentFilePath,
+    config.rootPath,
+    config.tsconfigPath || "",
+    config.alias?.value || "",
+    config.alias?.withSlash ? "1" : "0",
+  ].join("\0");
+
+  if (importResolveCache.has(cacheKey)) {
+    return importResolveCache.get(cacheKey);
+  }
+
+  let resolvedPath = null;
+
+  if (isRelativePath(importPath)) {
+    const currentDir = path.dirname(toAbsolutePath(currentFilePath));
+    resolvedPath = resolveFileCandidate(path.resolve(currentDir, importPath));
+  } else {
+    resolvedPath =
+      resolveWithTsConfigPaths(importPath, currentFilePath, config) ||
+      resolveWithConfiguredAlias(importPath, currentFilePath, config);
+  }
+
+  importResolveCache.set(cacheKey, resolvedPath);
+  return resolvedPath;
+}
+
+/**
+ * Get layer and slice information for an import target.
+ * Resolved filesystem paths are preferred, with legacy string parsing as fallback.
+ * @param {string} importPath - Path from import statement
+ * @param {string} currentFilePath - File that contains the import
+ * @param {Object} config - Configuration options
+ * @return {{ resolvedPath: string|null, layer: string|null, slice: string|null }}
+ */
+export function getImportTargetInfo(importPath, currentFilePath, config) {
+  const resolvedPath = resolveImportPath(importPath, currentFilePath, config);
+
+  if (resolvedPath) {
+    return {
+      resolvedPath,
+      layer: extractLayerFromPath(resolvedPath, config),
+      slice: extractSliceFromPath(resolvedPath, config),
+    };
+  }
+
+  if (isRelativePath(importPath)) {
+    const unresolvedPath = normalizePath(
+      path.resolve(path.dirname(toAbsolutePath(currentFilePath)), importPath),
+    );
+
+    return {
+      resolvedPath: null,
+      layer: extractLayerFromPath(unresolvedPath, config),
+      slice: extractSliceFromPath(unresolvedPath, config),
+    };
+  }
+
+  return {
+    resolvedPath: null,
+    layer: extractLayerFromImportPath(importPath, config),
+    slice: extractSliceFromImportPath(importPath, config),
+  };
+}
+
+function getEntityCrossImportInfoFromSegments(segments, config) {
+  if (segments.length < 4 || segments[2] !== "@x") {
+    return null;
+  }
+
+  const layer = findLayerBySegment(segments[0], config);
+  if (layer !== "entities") {
+    return null;
+  }
+
+  return {
+    layer,
+    targetSlice: segments[1],
+    consumerSlice: segments[3].replace(/\.[^.]+$/, ""),
+  };
+}
+
+/**
+ * Extract FSD Entities @x public API information from an import target.
+ * @param {string} importPath - Path from import statement
+ * @param {string} currentFilePath - File that contains the import
+ * @param {Object} config - Configuration options
+ * @return {{ layer: string, targetSlice: string, consumerSlice: string }|null}
+ */
+export function getEntityCrossImportPublicApiInfo(
+  importPath,
+  currentFilePath,
+  config,
+) {
+  const resolvedPath = resolveImportPath(importPath, currentFilePath, config);
+
+  if (resolvedPath) {
+    const relativePath = getRelativePathFromRoot(resolvedPath, config.rootPath);
+    if (relativePath) {
+      const resolvedInfo = getEntityCrossImportInfoFromSegments(
+        relativePath.split("/").filter(Boolean),
+        config,
+      );
+
+      if (resolvedInfo) {
+        return resolvedInfo;
+      }
+    }
+  }
+
+  const pathWithoutAlias = getImportPathWithoutAlias(importPath, config);
+  if (!pathWithoutAlias) {
+    return null;
+  }
+
+  return getEntityCrossImportInfoFromSegments(
+    pathWithoutAlias.split("/").filter(Boolean),
+    config,
+  );
 }
 
 /**

--- a/tests/fixtures/explicit-tsconfig/tsconfig.json
+++ b/tests/fixtures/explicit-tsconfig/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@explicit-articles/*": ["../resolve-project/src/pages/articles/*"]
+    }
+  }
+}

--- a/tests/fixtures/resolve-project/src/app/index.ts
+++ b/tests/fixtures/resolve-project/src/app/index.ts
@@ -1,0 +1,1 @@
+export { initProviders } from "./providers/init";

--- a/tests/fixtures/resolve-project/src/app/providers/init.ts
+++ b/tests/fixtures/resolve-project/src/app/providers/init.ts
@@ -1,0 +1,1 @@
+export const initProviders = {};

--- a/tests/fixtures/resolve-project/src/app/store/index.ts
+++ b/tests/fixtures/resolve-project/src/app/store/index.ts
@@ -1,0 +1,1 @@
+export const appStore = {};

--- a/tests/fixtures/resolve-project/src/entities/artist/model/artist.ts
+++ b/tests/fixtures/resolve-project/src/entities/artist/model/artist.ts
@@ -1,0 +1,1 @@
+export const artist = {};

--- a/tests/fixtures/resolve-project/src/entities/playlist/model/playlist.ts
+++ b/tests/fixtures/resolve-project/src/entities/playlist/model/playlist.ts
@@ -1,0 +1,1 @@
+export const playlist = {};

--- a/tests/fixtures/resolve-project/src/entities/song/@x/artist.ts
+++ b/tests/fixtures/resolve-project/src/entities/song/@x/artist.ts
@@ -1,0 +1,1 @@
+export type SongForArtist = {};

--- a/tests/fixtures/resolve-project/src/entities/song/@x/playlist.ts
+++ b/tests/fixtures/resolve-project/src/entities/song/@x/playlist.ts
@@ -1,0 +1,1 @@
+export type SongForPlaylist = {};

--- a/tests/fixtures/resolve-project/src/entities/song/index.ts
+++ b/tests/fixtures/resolve-project/src/entities/song/index.ts
@@ -1,0 +1,1 @@
+export const songPublicApi = {};

--- a/tests/fixtures/resolve-project/src/entities/song/model/song.ts
+++ b/tests/fixtures/resolve-project/src/entities/song/model/song.ts
@@ -1,0 +1,1 @@
+export const songInternal = {};

--- a/tests/fixtures/resolve-project/src/entities/user/api/userApi.ts
+++ b/tests/fixtures/resolve-project/src/entities/user/api/userApi.ts
@@ -1,0 +1,1 @@
+export const fetchUser = async () => null;

--- a/tests/fixtures/resolve-project/src/entities/user/index.ts
+++ b/tests/fixtures/resolve-project/src/entities/user/index.ts
@@ -1,0 +1,1 @@
+export const userPublicApi = {};

--- a/tests/fixtures/resolve-project/src/entities/user/model/session.ts
+++ b/tests/fixtures/resolve-project/src/entities/user/model/session.ts
@@ -1,0 +1,1 @@
+export const userSession = {};

--- a/tests/fixtures/resolve-project/src/entities/user/ui/UserBadge.tsx
+++ b/tests/fixtures/resolve-project/src/entities/user/ui/UserBadge.tsx
@@ -1,0 +1,3 @@
+export function UserBadge() {
+  return null;
+}

--- a/tests/fixtures/resolve-project/src/features/auth/api/login.ts
+++ b/tests/fixtures/resolve-project/src/features/auth/api/login.ts
@@ -1,0 +1,1 @@
+export const login = async () => null;

--- a/tests/fixtures/resolve-project/src/features/auth/index.ts
+++ b/tests/fixtures/resolve-project/src/features/auth/index.ts
@@ -1,0 +1,1 @@
+export const authPublicApi = {};

--- a/tests/fixtures/resolve-project/src/features/auth/lib/utils.ts
+++ b/tests/fixtures/resolve-project/src/features/auth/lib/utils.ts
@@ -1,0 +1,1 @@
+export const isLoggedIn = () => false;

--- a/tests/fixtures/resolve-project/src/features/auth/model/session.ts
+++ b/tests/fixtures/resolve-project/src/features/auth/model/session.ts
@@ -1,0 +1,1 @@
+export const authSession = {};

--- a/tests/fixtures/resolve-project/src/features/auth/ui/LoginForm.tsx
+++ b/tests/fixtures/resolve-project/src/features/auth/ui/LoginForm.tsx
@@ -1,0 +1,3 @@
+export function LoginForm() {
+  return null;
+}

--- a/tests/fixtures/resolve-project/src/features/profile/ui/ProfilePage.tsx
+++ b/tests/fixtures/resolve-project/src/features/profile/ui/ProfilePage.tsx
@@ -1,0 +1,3 @@
+export function ProfilePage() {
+  return null;
+}

--- a/tests/fixtures/resolve-project/src/pages/articles/api/queries.ts
+++ b/tests/fixtures/resolve-project/src/pages/articles/api/queries.ts
@@ -1,0 +1,1 @@
+export const articleSections = [];

--- a/tests/fixtures/resolve-project/src/pages/articles/index.ts
+++ b/tests/fixtures/resolve-project/src/pages/articles/index.ts
@@ -1,0 +1,1 @@
+export { ArticlesLayout } from "./ui/articles-page";

--- a/tests/fixtures/resolve-project/src/pages/articles/ui/articles-page.tsx
+++ b/tests/fixtures/resolve-project/src/pages/articles/ui/articles-page.tsx
@@ -1,0 +1,3 @@
+export function ArticlesLayout() {
+  return null;
+}

--- a/tests/fixtures/resolve-project/src/pages/articles/ui/articles-pending-page.tsx
+++ b/tests/fixtures/resolve-project/src/pages/articles/ui/articles-pending-page.tsx
@@ -1,0 +1,3 @@
+export function ArticlesPendingPage() {
+  return null;
+}

--- a/tests/fixtures/resolve-project/src/pages/profile/ui/profile-page.tsx
+++ b/tests/fixtures/resolve-project/src/pages/profile/ui/profile-page.tsx
@@ -1,0 +1,3 @@
+export function ProfilePage() {
+  return null;
+}

--- a/tests/fixtures/resolve-project/src/processes/onboarding/index.ts
+++ b/tests/fixtures/resolve-project/src/processes/onboarding/index.ts
@@ -1,0 +1,1 @@
+export { onboardingFlow } from "./model/flow";

--- a/tests/fixtures/resolve-project/src/processes/onboarding/model/flow.ts
+++ b/tests/fixtures/resolve-project/src/processes/onboarding/model/flow.ts
@@ -1,0 +1,1 @@
+export const onboardingFlow = {};

--- a/tests/fixtures/resolve-project/src/shared/api/http.ts
+++ b/tests/fixtures/resolve-project/src/shared/api/http.ts
@@ -1,0 +1,1 @@
+export const httpClient = {};

--- a/tests/fixtures/resolve-project/src/shared/config/index.ts
+++ b/tests/fixtures/resolve-project/src/shared/config/index.ts
@@ -1,0 +1,1 @@
+export const sharedConfig = {};

--- a/tests/fixtures/resolve-project/src/shared/lib/date.ts
+++ b/tests/fixtures/resolve-project/src/shared/lib/date.ts
@@ -1,0 +1,1 @@
+export const formatDate = () => "";

--- a/tests/fixtures/resolve-project/src/shared/store/index.ts
+++ b/tests/fixtures/resolve-project/src/shared/store/index.ts
@@ -1,0 +1,1 @@
+export const sharedStore = {};

--- a/tests/fixtures/resolve-project/src/shared/ui/button/Button.tsx
+++ b/tests/fixtures/resolve-project/src/shared/ui/button/Button.tsx
@@ -1,0 +1,3 @@
+export function ButtonView() {
+  return null;
+}

--- a/tests/fixtures/resolve-project/src/shared/ui/button/index.ts
+++ b/tests/fixtures/resolve-project/src/shared/ui/button/index.ts
@@ -1,0 +1,1 @@
+export const Button = {};

--- a/tests/fixtures/resolve-project/src/widgets/header/index.ts
+++ b/tests/fixtures/resolve-project/src/widgets/header/index.ts
@@ -1,0 +1,1 @@
+export const Header = {};

--- a/tests/fixtures/resolve-project/src/widgets/header/model/header-model.ts
+++ b/tests/fixtures/resolve-project/src/widgets/header/model/header-model.ts
@@ -1,0 +1,1 @@
+export const headerModel = {};

--- a/tests/fixtures/resolve-project/src/widgets/header/ui/Header.tsx
+++ b/tests/fixtures/resolve-project/src/widgets/header/ui/Header.tsx
@@ -1,0 +1,3 @@
+export function Header() {
+  return null;
+}

--- a/tests/fixtures/resolve-project/tsconfig.json
+++ b/tests/fixtures/resolve-project/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@articles/*": ["src/pages/articles/*"],
+      "@profile/*": ["src/pages/profile/*"],
+      "@page/*": ["src/pages/*/index.ts"],
+      "@multi/*": ["src/missing/*", "src/pages/*"],
+      "@auth": ["src/features/auth/index.ts"],
+      "@auth/*": ["src/features/auth/*"],
+      "@entities/*": ["src/entities/*"],
+      "@user": ["src/entities/user/index.ts"],
+      "@user/*": ["src/entities/user/*"],
+      "@ui-button": ["src/shared/ui/button/index.ts"],
+      "@song": ["src/entities/song/index.ts"],
+      "@song/*": ["src/entities/song/*"],
+      "@song-for-artist": ["src/entities/song/@x/artist.ts"],
+      "@song-for-playlist": ["src/entities/song/@x/playlist.ts"]
+    }
+  }
+}

--- a/tests/forbidden-imports-same-slice.test.js
+++ b/tests/forbidden-imports-same-slice.test.js
@@ -1,0 +1,141 @@
+import { ESLint } from "eslint";
+import tsParser from "@typescript-eslint/parser";
+import { describe, expect, it } from "vitest";
+
+import fsdPlugin from "../src/index.js";
+
+function createEslint(ruleOptions = {}) {
+  return new ESLint({
+    overrideConfigFile: true,
+    ignore: false,
+    overrideConfig: [
+      {
+        files: ["**/*.ts", "**/*.tsx"],
+        languageOptions: {
+          parser: tsParser,
+          ecmaVersion: 2022,
+          sourceType: "module",
+        },
+        plugins: {
+          fsd: fsdPlugin,
+        },
+        rules: {
+          "fsd/forbidden-imports": ["error", ruleOptions],
+        },
+      },
+    ],
+  });
+}
+
+async function lintText(code, filePath, ruleOptions) {
+  const eslint = createEslint(ruleOptions);
+  const [result] = await eslint.lintText(code, { filePath });
+
+  return result.messages;
+}
+
+describe("forbidden-imports same-slice aliases", () => {
+  it("allows issue #26 pages same-slice imports with slash aliases", async () => {
+    const messages = await lintText(
+      `
+        import { articleSections } from "@/pages/articles/api/queries";
+        import { ArticlesLayout } from "@/pages/articles/ui/articles-page";
+      `,
+      "apps/web/src/pages/articles/ui/articles-pending-page.tsx",
+      {
+        rootPath: "/apps/web/src/",
+        alias: {
+          value: "@",
+          withSlash: true,
+        },
+      },
+    );
+
+    expect(messages).toEqual([]);
+  });
+
+  it("keeps reporting pages cross-slice imports with slash aliases", async () => {
+    const messages = await lintText(
+      'import { ProfilePage } from "@/pages/profile/ui/profile-page";',
+      "apps/web/src/pages/articles/ui/articles-pending-page.tsx",
+      {
+        rootPath: "/apps/web/src/",
+        alias: {
+          value: "@",
+          withSlash: true,
+        },
+      },
+    );
+
+    expect(messages.map((message) => message.ruleId)).toEqual([
+      "fsd/forbidden-imports",
+    ]);
+  });
+
+  it("allows same-slice imports with default non-slash aliases", async () => {
+    const messages = await lintText(
+      'import { session } from "@features/auth/model/session";',
+      "src/features/auth/ui/LoginForm.tsx",
+    );
+
+    expect(messages).toEqual([]);
+  });
+
+  it("keeps reporting cross-slice imports with default non-slash aliases", async () => {
+    const messages = await lintText(
+      'import { profileService } from "@features/profile/model/service";',
+      "src/features/auth/ui/LoginForm.tsx",
+    );
+
+    expect(messages.map((message) => message.ruleId)).toEqual([
+      "fsd/forbidden-imports",
+    ]);
+  });
+
+  it("supports same-slice aliases when a layer folder is renamed", async () => {
+    const ruleOptions = {
+      rootPath: "/renamed/src/",
+      alias: {
+        value: "~",
+        withSlash: true,
+      },
+      layers: {
+        pages: {
+          pattern: "screens",
+        },
+      },
+    };
+
+    await expect(
+      lintText(
+        'import { selectDashboardTitle } from "~/screens/dashboard/model/selectors";',
+        "renamed/src/screens/dashboard/ui/DashboardScreen.tsx",
+        ruleOptions,
+      ),
+    ).resolves.toEqual([]);
+
+    await expect(
+      lintText(
+        'import { selectProfileTitle } from "~/screens/profile/model/selectors";',
+        "renamed/src/screens/dashboard/ui/DashboardScreen.tsx",
+        ruleOptions,
+      ),
+    ).resolves.toHaveLength(1);
+  });
+
+  it("does not weaken normal layer direction checks", async () => {
+    await expect(
+      lintText(
+        'import { Header } from "@widgets/header";',
+        "src/pages/dashboard/ui/DashboardPage.tsx",
+      ),
+    ).resolves.toEqual([]);
+
+    await expect(
+      lintText(
+        'import { DashboardPage } from "@pages/dashboard";',
+        "src/entities/user/model/user.ts",
+      ),
+    ).resolves.toHaveLength(1);
+  });
+});

--- a/tests/fsd-comprehensive.test.js
+++ b/tests/fsd-comprehensive.test.js
@@ -1,0 +1,1045 @@
+import { ESLint } from "eslint";
+import tsParser from "@typescript-eslint/parser";
+import { describe, expect, it } from "vitest";
+
+import fsdPlugin from "../src/index.js";
+
+const fixtureRoot = {
+  rootPath: "/tests/fixtures/resolve-project/src/",
+};
+
+const slashAlias = {
+  alias: {
+    value: "@",
+    withSlash: true,
+  },
+};
+
+function createEslint(rules) {
+  return new ESLint({
+    overrideConfigFile: true,
+    ignore: false,
+    overrideConfig: [
+      {
+        files: ["**/*.ts", "**/*.tsx"],
+        languageOptions: {
+          parser: tsParser,
+          ecmaVersion: 2022,
+          sourceType: "module",
+        },
+        plugins: {
+          fsd: fsdPlugin,
+        },
+        rules,
+      },
+    ],
+  });
+}
+
+async function lintText(code, filePath, rules) {
+  const eslint = createEslint(rules);
+  const [result] = await eslint.lintText(code, { filePath });
+  return result.messages;
+}
+
+function ruleIds(messages) {
+  return messages.map((message) => message.ruleId);
+}
+
+function messageIds(messages) {
+  return messages.map((message) => message.messageId);
+}
+
+describe("FSD 2.x — full layer-pair matrix for forbidden-imports", () => {
+  const layerCases = [
+    // Allowed downward-only direction.
+    ["app imports processes", "app/App.tsx", "@processes/onboarding", []],
+    ["app imports pages", "app/App.tsx", "@pages/articles", []],
+    ["app imports widgets", "app/App.tsx", "@widgets/header", []],
+    ["app imports features", "app/App.tsx", "@features/auth", []],
+    ["app imports entities", "app/App.tsx", "@entities/user", []],
+    ["app imports shared", "app/App.tsx", "@shared/lib/date", []],
+    [
+      "processes imports pages",
+      "processes/onboarding/model/step.ts",
+      "@pages/articles",
+      [],
+    ],
+    [
+      "processes imports features",
+      "processes/onboarding/model/step.ts",
+      "@features/auth",
+      [],
+    ],
+    [
+      "processes imports entities",
+      "processes/onboarding/model/step.ts",
+      "@entities/user",
+      [],
+    ],
+    [
+      "pages imports widgets",
+      "pages/articles/ui/articles-page.tsx",
+      "@widgets/header",
+      [],
+    ],
+    [
+      "pages imports features",
+      "pages/articles/ui/articles-page.tsx",
+      "@features/auth",
+      [],
+    ],
+    [
+      "pages imports entities",
+      "pages/articles/ui/articles-page.tsx",
+      "@entities/user",
+      [],
+    ],
+    [
+      "pages imports shared",
+      "pages/articles/ui/articles-page.tsx",
+      "@shared/lib/date",
+      [],
+    ],
+    [
+      "widgets imports features",
+      "widgets/header/ui/Header.tsx",
+      "@features/auth",
+      [],
+    ],
+    [
+      "widgets imports entities",
+      "widgets/header/ui/Header.tsx",
+      "@entities/user",
+      [],
+    ],
+    [
+      "widgets imports shared",
+      "widgets/header/ui/Header.tsx",
+      "@shared/lib/date",
+      [],
+    ],
+    [
+      "features imports entities",
+      "features/auth/model/session.ts",
+      "@entities/user",
+      [],
+    ],
+    [
+      "features imports shared",
+      "features/auth/model/session.ts",
+      "@shared/lib/date",
+      [],
+    ],
+    [
+      "entities imports shared",
+      "entities/user/model/session.ts",
+      "@shared/lib/date",
+      [],
+    ],
+
+    // Disallowed upward direction.
+    [
+      "processes cannot import app",
+      "processes/onboarding/model/step.ts",
+      "@app/providers",
+      ["fsd/forbidden-imports"],
+    ],
+    [
+      "pages cannot import processes",
+      "pages/articles/ui/articles-page.tsx",
+      "@processes/onboarding",
+      ["fsd/forbidden-imports"],
+    ],
+    [
+      "widgets cannot import pages",
+      "widgets/header/ui/Header.tsx",
+      "@pages/articles",
+      ["fsd/forbidden-imports"],
+    ],
+    [
+      "features cannot import widgets",
+      "features/auth/model/session.ts",
+      "@widgets/header",
+      ["fsd/forbidden-imports"],
+    ],
+    [
+      "entities cannot import features",
+      "entities/user/model/session.ts",
+      "@features/auth",
+      ["fsd/forbidden-imports"],
+    ],
+    [
+      "shared cannot import entities",
+      "shared/lib/date.ts",
+      "@entities/user",
+      ["fsd/forbidden-imports"],
+    ],
+    [
+      "shared cannot import features",
+      "shared/lib/date.ts",
+      "@features/auth",
+      ["fsd/forbidden-imports"],
+    ],
+  ];
+
+  it.each(layerCases)("%s", async (_name, filePath, importPath, expected) => {
+    const messages = await lintText(
+      `import { thing } from "${importPath}";`,
+      `tests/fixtures/resolve-project/src/${filePath}`,
+      {
+        "fsd/forbidden-imports": ["error", fixtureRoot],
+      },
+    );
+
+    expect(ruleIds(messages)).toEqual(expected);
+  });
+});
+
+describe("FSD 2.x — segment access within the same slice", () => {
+  it.each([
+    ["ui imports model", "features/auth/ui/LoginForm.tsx", "../model/session"],
+    ["ui imports api", "features/auth/ui/LoginForm.tsx", "../api/login"],
+    ["ui imports lib", "features/auth/ui/LoginForm.tsx", "../lib/utils"],
+    ["model imports lib", "features/auth/model/session.ts", "../lib/utils"],
+    ["model imports api", "features/auth/model/session.ts", "../api/login"],
+    ["api imports lib", "features/auth/api/login.ts", "../lib/utils"],
+    ["lib imports model", "features/auth/lib/utils.ts", "../model/session"],
+  ])("allows %s with relative paths", async (_name, filePath, importPath) => {
+    const messages = await lintText(
+      `import { thing } from "${importPath}";`,
+      `tests/fixtures/resolve-project/src/${filePath}`,
+      {
+        "fsd/forbidden-imports": ["error", fixtureRoot],
+        "fsd/no-cross-slice-dependency": ["error", fixtureRoot],
+      },
+    );
+
+    expect(messages).toEqual([]);
+  });
+
+  it("allows same-slice segment access through tsconfig path aliases", async () => {
+    const messages = await lintText(
+      `
+        import { authSession } from "@auth/model/session";
+        import { LoginForm } from "@auth/ui/LoginForm";
+        import { login } from "@auth/api/login";
+        import { isLoggedIn } from "@auth/lib/utils";
+      `,
+      "tests/fixtures/resolve-project/src/features/auth/model/session.ts",
+      {
+        "fsd/forbidden-imports": ["error", fixtureRoot],
+        "fsd/no-cross-slice-dependency": ["error", fixtureRoot],
+      },
+    );
+
+    expect(messages).toEqual([]);
+  });
+});
+
+describe("FSD 2.x — public API enforcement variations", () => {
+  it("allows root slice public API for restricted layers", async () => {
+    const messages = await lintText(
+      `
+        import { authPublicApi } from "@features/auth";
+        import { userPublicApi } from "@entities/user";
+        import { Header } from "@widgets/header";
+      `,
+      "src/pages/articles/ui/articles-page.tsx",
+      {
+        "fsd/no-public-api-sidestep": "error",
+      },
+    );
+
+    expect(messages).toEqual([]);
+  });
+
+  it("flags direct file imports past the segment level", async () => {
+    const messages = await lintText(
+      `
+        import { sessionInternal } from "@features/auth/model/session";
+        import { fetchUser } from "@entities/user/api/userApi";
+      `,
+      "src/pages/articles/ui/articles-page.tsx",
+      {
+        "fsd/no-public-api-sidestep": "error",
+      },
+    );
+
+    expect(messageIds(messages)).toEqual(["noDirectImport", "noDirectImport"]);
+  });
+
+  it("flags direct nested file imports when allowSegmentImports is false", async () => {
+    const messages = await lintText(
+      `
+        import { sessionInternal } from "@features/auth/model/session";
+        import { fetchUser } from "@entities/user/api/userApi";
+      `,
+      "src/pages/articles/ui/articles-page.tsx",
+      {
+        "fsd/no-public-api-sidestep": [
+          "error",
+          {
+            publicApi: {
+              allowSegmentImports: false,
+            },
+          },
+        ],
+      },
+    );
+
+    expect(messageIds(messages)).toEqual(["noDirectImport", "noDirectImport"]);
+  });
+
+  it("treats segment-level index imports as public API by default", async () => {
+    const messages = await lintText(
+      `
+        import { authModel } from "@features/auth/model";
+        import { authUi } from "@features/auth/ui";
+        import { userApi } from "@entities/user/api";
+      `,
+      "src/pages/articles/ui/articles-page.tsx",
+      {
+        "fsd/no-public-api-sidestep": "error",
+      },
+    );
+
+    expect(messages).toEqual([]);
+  });
+
+  it("does not enforce shared public API by default", async () => {
+    const messages = await lintText(
+      `
+        import { Button } from "@shared/ui/Button";
+        import { formatDate } from "@shared/lib/date";
+        import { httpClient } from "@shared/api/http";
+      `,
+      "src/pages/articles/ui/articles-page.tsx",
+      {
+        "fsd/no-public-api-sidestep": "error",
+      },
+    );
+
+    expect(messages).toEqual([]);
+  });
+
+  it("enforces shared segment-level imports when enforceShared is true", async () => {
+    const messages = await lintText(
+      `
+        import { Button } from "@shared/ui/Button";
+        import { formatDate } from "@shared/lib/date";
+        import { sharedConfig } from "@shared/config";
+        import { sharedUi } from "@shared/ui";
+      `,
+      "src/pages/articles/ui/articles-page.tsx",
+      {
+        "fsd/no-public-api-sidestep": [
+          "error",
+          {
+            publicApi: {
+              enforceShared: true,
+            },
+          },
+        ],
+      },
+    );
+
+    expect(messageIds(messages)).toEqual(["noDirectImport", "noDirectImport"]);
+  });
+
+  it("requires root-level shared imports when both enforceShared and !allowSegmentImports", async () => {
+    const messages = await lintText(
+      `
+        import { sharedRoot } from "@shared";
+        import { sharedRootIndex } from "@shared/index";
+        import { sharedUi } from "@shared/ui";
+        import { Button } from "@shared/ui/Button";
+      `,
+      "src/pages/articles/ui/articles-page.tsx",
+      {
+        "fsd/no-public-api-sidestep": [
+          "error",
+          {
+            publicApi: {
+              enforceShared: true,
+              allowSegmentImports: false,
+            },
+          },
+        ],
+      },
+    );
+
+    expect(messageIds(messages)).toEqual(["noDirectImport", "noDirectImport"]);
+  });
+
+  it("can extend enforcement to additional layers like pages", async () => {
+    const messages = await lintText(
+      `
+        import { ArticlesLayout } from "@pages/articles/ui/articles-page";
+        import { articleSections } from "@pages/articles/api/queries";
+      `,
+      "src/app/App.tsx",
+      {
+        "fsd/no-public-api-sidestep": [
+          "error",
+          {
+            publicApi: {
+              enforceForLayers: ["pages"],
+              allowSegmentImports: false,
+            },
+          },
+        ],
+      },
+    );
+
+    expect(messageIds(messages)).toEqual(["noDirectImport", "noDirectImport"]);
+  });
+
+  it("treats every recognized index file extension as the public API", async () => {
+    const messages = await lintText(
+      `
+        import a from "@features/auth/index.ts";
+        import b from "@features/auth/index.tsx";
+        import c from "@features/auth/index.js";
+        import d from "@features/auth/index.jsx";
+      `,
+      "src/pages/articles/ui/articles-page.tsx",
+      {
+        "fsd/no-public-api-sidestep": "error",
+      },
+    );
+
+    expect(messages).toEqual([]);
+  });
+});
+
+describe("FSD 2.x — app and shared exemptions", () => {
+  it("does not block app-internal segment crossings", async () => {
+    const messages = await lintText(
+      `
+        import { initProviders } from "./providers/init";
+        import { appStore } from "./store";
+      `,
+      "tests/fixtures/resolve-project/src/app/App.tsx",
+      {
+        "fsd/no-cross-slice-dependency": ["error", fixtureRoot],
+        "fsd/forbidden-imports": ["error", fixtureRoot],
+      },
+    );
+
+    expect(messages).toEqual([]);
+  });
+
+  it("does not treat shared sub-folders as cross-slice imports", async () => {
+    const messages = await lintText(
+      `
+        import { Button } from "../button";
+        import { formatDate } from "../../lib/date";
+        import { httpClient } from "../../api/http";
+      `,
+      "tests/fixtures/resolve-project/src/shared/ui/button/Button.tsx",
+      {
+        "fsd/no-cross-slice-dependency": ["error", fixtureRoot],
+        "fsd/forbidden-imports": ["error", fixtureRoot],
+      },
+    );
+
+    expect(messages).toEqual([]);
+  });
+});
+
+describe("FSD 2.x — import expression variations", () => {
+  it("type-only imports are checked the same as value imports", async () => {
+    const messages = await lintText(
+      'import type { AuthSession } from "@features/auth/model/session";',
+      "src/features/profile/ui/ProfilePage.tsx",
+      {
+        "fsd/no-cross-slice-dependency": "error",
+        "fsd/no-public-api-sidestep": "error",
+      },
+    );
+
+    expect(ruleIds(messages).sort()).toEqual([
+      "fsd/no-cross-slice-dependency",
+      "fsd/no-public-api-sidestep",
+    ]);
+  });
+
+  it("does not currently inspect ExportNamedDeclaration with source", async () => {
+    // Note: this documents existing behavior — re-exports bypass FSD checks.
+    const messages = await lintText(
+      'export { authSession } from "@features/auth/model/session";',
+      "src/features/profile/model/session.ts",
+      {
+        "fsd/no-cross-slice-dependency": "error",
+        "fsd/no-public-api-sidestep": "error",
+        "fsd/forbidden-imports": "error",
+      },
+    );
+
+    expect(messages).toEqual([]);
+  });
+
+  it("side-effect-only imports still go through layer checks", async () => {
+    const messages = await lintText(
+      'import "@processes/onboarding";',
+      "src/pages/articles/ui/articles-page.tsx",
+      {
+        "fsd/forbidden-imports": "error",
+      },
+    );
+
+    expect(ruleIds(messages)).toEqual(["fsd/forbidden-imports"]);
+  });
+
+  it("dynamic imports are checked across all rules", async () => {
+    const messages = await lintText(
+      'const m = await import("@features/auth/model/session");',
+      "src/features/profile/model/session.ts",
+      {
+        "fsd/no-cross-slice-dependency": "error",
+        "fsd/no-public-api-sidestep": "error",
+      },
+    );
+
+    expect(ruleIds(messages).sort()).toEqual([
+      "fsd/no-cross-slice-dependency",
+      "fsd/no-public-api-sidestep",
+    ]);
+  });
+
+  it("ignores dynamic imports with a non-literal specifier", async () => {
+    const messages = await lintText(
+      "const m = await import(somePath);",
+      "src/features/profile/model/session.ts",
+      {
+        "fsd/no-cross-slice-dependency": "error",
+        "fsd/no-public-api-sidestep": "error",
+      },
+    );
+
+    expect(messages).toEqual([]);
+  });
+
+  it("ignores third-party packages and node built-ins", async () => {
+    const messages = await lintText(
+      `
+        import React from "react";
+        import path from "path";
+        import { useDispatch } from "react-redux";
+        import scoped from "@types/react";
+      `,
+      "src/features/auth/model/session.ts",
+      {
+        "fsd/forbidden-imports": "error",
+        "fsd/no-cross-slice-dependency": "error",
+        "fsd/no-public-api-sidestep": "error",
+      },
+    );
+
+    expect(messages).toEqual([]);
+  });
+});
+
+describe("FSD 2.x — alias variations", () => {
+  it.each([
+    ["default no-slash alias", undefined, "@features/auth/model/x"],
+    [
+      "object alias with slash",
+      { ...slashAlias, rootPath: "/src/" },
+      "@/features/auth/model/x",
+    ],
+    [
+      "string alias ending with slash",
+      { alias: "@/", rootPath: "/src/" },
+      "@/features/auth/model/x",
+    ],
+    [
+      "tilde alias",
+      { alias: { value: "~", withSlash: true }, rootPath: "/src/" },
+      "~/features/auth/model/x",
+    ],
+  ])("still flags cross-slice with %s", async (_name, options, importPath) => {
+    const messages = await lintText(
+      `import { x } from "${importPath}";`,
+      "src/features/profile/model/profile.ts",
+      {
+        "fsd/no-cross-slice-dependency": ["error", options || {}],
+      },
+    );
+
+    expect(messageIds(messages)).toEqual(["noFeatureDependency"]);
+  });
+
+  it.each([
+    ["default no-slash alias", undefined, "@features/profile/model/x"],
+    [
+      "object alias with slash",
+      { ...slashAlias, rootPath: "/src/" },
+      "@/features/profile/model/x",
+    ],
+    [
+      "tilde alias",
+      { alias: { value: "~", withSlash: true }, rootPath: "/src/" },
+      "~/features/profile/model/x",
+    ],
+  ])(
+    "permits same-slice imports with %s",
+    async (_name, options, importPath) => {
+      const messages = await lintText(
+        `import { x } from "${importPath}";`,
+        "src/features/profile/ui/ProfileView.tsx",
+        {
+          "fsd/no-cross-slice-dependency": ["error", options || {}],
+          "fsd/forbidden-imports": ["error", options || {}],
+        },
+      );
+
+      expect(messages).toEqual([]);
+    },
+  );
+});
+
+describe("FSD 2.x — folder pattern with numeric prefixes", () => {
+  const folderConfig = {
+    rootPath: "/src/",
+    folderPattern: {
+      enabled: true,
+      regex: "^(\\d+_)?(.*)$",
+      extractionGroup: 2,
+    },
+  };
+
+  it("recognizes the file's layer when the folder is numeric-prefixed", async () => {
+    const messages = await lintText(
+      'import { authPublicApi } from "@features/auth";',
+      "src/06_entities/user/model/user.ts",
+      {
+        "fsd/forbidden-imports": ["error", folderConfig],
+      },
+    );
+
+    expect(ruleIds(messages)).toEqual(["fsd/forbidden-imports"]);
+  });
+
+  it("permits same-layer numeric-prefixed file imports through aliases", async () => {
+    const messages = await lintText(
+      'import { Button } from "@shared/ui/Button";',
+      "src/05_features/auth/model/session.ts",
+      {
+        "fsd/forbidden-imports": ["error", folderConfig],
+      },
+    );
+
+    expect(messages).toEqual([]);
+  });
+});
+
+describe("FSD 2.x — test file exemption", () => {
+  it.each([
+    ["unit test", "src/features/auth/model/session.test.ts"],
+    ["spec test", "src/features/auth/ui/LoginForm.spec.tsx"],
+    ["storybook story", "src/features/auth/ui/LoginForm.stories.tsx"],
+    ["StoreDecorator helper", "src/shared/StoreDecorator.tsx"],
+  ])("forbidden-imports skips %s", async (_name, filePath) => {
+    const messages = await lintText(
+      'import { LoginPage } from "@pages/login";',
+      filePath,
+      {
+        "fsd/forbidden-imports": "error",
+      },
+    );
+
+    expect(messages).toEqual([]);
+  });
+
+  it("no-cross-slice-dependency skips test files", async () => {
+    const messages = await lintText(
+      'import { authSession } from "@features/auth/model/session";',
+      "src/features/profile/model/profile.test.ts",
+      {
+        "fsd/no-cross-slice-dependency": "error",
+      },
+    );
+
+    expect(messages).toEqual([]);
+  });
+
+  it("no-public-api-sidestep skips test files", async () => {
+    const messages = await lintText(
+      'import { sessionInternal } from "@features/auth/model/session";',
+      "src/pages/articles/ui/articles-page.test.tsx",
+      {
+        "fsd/no-public-api-sidestep": [
+          "error",
+          { publicApi: { allowSegmentImports: false } },
+        ],
+      },
+    );
+
+    expect(messages).toEqual([]);
+  });
+});
+
+describe("FSD 2.x — ignoreImportPatterns", () => {
+  it("ignores stylesheets and image assets when configured", async () => {
+    const messages = await lintText(
+      `
+        import "./LoginForm.module.css";
+        import logo from "./logo.svg";
+        import "../../shared/styles/global.scss";
+      `,
+      "src/features/auth/ui/LoginForm.tsx",
+      {
+        "fsd/forbidden-imports": [
+          "error",
+          {
+            ignoreImportPatterns: ["\\.css$", "\\.scss$", "\\.svg$"],
+          },
+        ],
+      },
+    );
+
+    expect(messages).toEqual([]);
+  });
+});
+
+describe("FSD 2.x — ordered-imports", () => {
+  it("flags an inverted order between layers", async () => {
+    const messages = await lintText(
+      `
+        import { user } from "@entities/user";
+        import { Header } from "@widgets/header";
+        import { Button } from "@shared/ui/Button";
+      `,
+      "src/pages/articles/ui/articles-page.tsx",
+      {
+        "fsd/ordered-imports": "error",
+      },
+    );
+
+    expect(ruleIds(messages)).toEqual(["fsd/ordered-imports"]);
+  });
+
+  it("accepts the canonical top-to-bottom order", async () => {
+    const messages = await lintText(
+      `
+        import { Header } from "@widgets/header";
+        import { authPublicApi } from "@features/auth";
+        import { userPublicApi } from "@entities/user";
+        import { Button } from "@shared/ui/Button";
+      `,
+      "src/pages/articles/ui/articles-page.tsx",
+      {
+        "fsd/ordered-imports": "error",
+      },
+    );
+
+    expect(messages).toEqual([]);
+  });
+
+  it("uses fs-resolved layer info from tsconfig path aliases", async () => {
+    const messages = await lintText(
+      `
+        import { userPublicApi } from "@user";
+        import { Header } from "@/widgets/header";
+        import { authPublicApi } from "@auth";
+      `,
+      "tests/fixtures/resolve-project/src/pages/articles/ui/articles-page.tsx",
+      {
+        "fsd/ordered-imports": [
+          "error",
+          {
+            ...fixtureRoot,
+            ...slashAlias,
+          },
+        ],
+      },
+    );
+
+    expect(ruleIds(messages)).toEqual(["fsd/ordered-imports"]);
+  });
+});
+
+describe("FSD 2.x — no-relative-imports", () => {
+  it("rejects cross-slice relative imports by default", async () => {
+    const messages = await lintText(
+      'import { authSession } from "../../auth/model/session";',
+      "src/features/profile/ui/ProfilePage.tsx",
+      {
+        "fsd/no-relative-imports": "error",
+      },
+    );
+
+    expect(ruleIds(messages)).toEqual(["fsd/no-relative-imports"]);
+  });
+
+  it("permits same-slice relative imports when allowSameSlice is true", async () => {
+    const messages = await lintText(
+      `
+        import { session } from "../model/session";
+        import { utils } from "../lib/utils";
+      `,
+      "src/features/auth/ui/LoginForm.tsx",
+      {
+        "fsd/no-relative-imports": ["error", { allowSameSlice: true }],
+      },
+    );
+
+    expect(messages).toEqual([]);
+  });
+
+  it("flags upward path traversal that escapes the slice", async () => {
+    const messages = await lintText(
+      'import { Button } from "../../../shared/ui/Button";',
+      "src/features/auth/ui/LoginForm.tsx",
+      {
+        "fsd/no-relative-imports": ["error", { allowSameSlice: true }],
+      },
+    );
+
+    expect(ruleIds(messages)).toEqual(["fsd/no-relative-imports"]);
+  });
+});
+
+describe("FSD 2.x — no-ui-in-business-logic", () => {
+  it("does not flag imports when the file's layer is outside default business-logic layers", async () => {
+    const messages = await lintText(
+      'import { Button } from "@shared/ui/Button";',
+      "src/entities/user/model/user.ts",
+      {
+        "fsd/no-ui-in-business-logic": "error",
+      },
+    );
+
+    expect(messages).toEqual([]);
+  });
+
+  it("ignores test files regardless of business-logic configuration", async () => {
+    const messages = await lintText(
+      'import { Button } from "@shared/ui/Button";',
+      "src/entities/user/model/user.test.ts",
+      {
+        "fsd/no-ui-in-business-logic": "error",
+      },
+    );
+
+    expect(messages).toEqual([]);
+  });
+
+  it("respects ignoreImportPatterns for assets", async () => {
+    const messages = await lintText(
+      'import "@features/auth/ui/styles.module.css";',
+      "src/entities/user/model/user.ts",
+      {
+        "fsd/no-ui-in-business-logic": [
+          "error",
+          { ignoreImportPatterns: ["\\.css$"] },
+        ],
+      },
+    );
+
+    expect(messages).toEqual([]);
+  });
+
+  it("does not flag external packages", async () => {
+    const messages = await lintText(
+      'import React from "react";',
+      "src/entities/user/model/user.ts",
+      {
+        "fsd/no-ui-in-business-logic": "error",
+      },
+    );
+
+    expect(messages).toEqual([]);
+  });
+});
+
+describe("FSD 2.x — no-global-store-imports", () => {
+  it.each([
+    ["app store nested path", "@/app/store/index"],
+    ["shared store nested path", "@/shared/store/global"],
+    ["generic store substring", "@/redux/store/users"],
+    ["zustand path", "@/zustand/global"],
+    ["mobx path", "@/mobx/state"],
+    ["recoil path", "@/recoil/atoms"],
+  ])("blocks %s imports outside test files", async (_name, importPath) => {
+    const messages = await lintText(
+      `import { state } from "${importPath}";`,
+      "src/features/auth/model/session.ts",
+      {
+        "fsd/no-global-store-imports": "error",
+      },
+    );
+
+    expect(ruleIds(messages)).toEqual(["fsd/no-global-store-imports"]);
+  });
+
+  it("respects custom allowedPaths overrides", async () => {
+    const messages = await lintText(
+      'import { useUserSelector } from "@/app/store/selectors/user";',
+      "src/features/auth/ui/LoginForm.tsx",
+      {
+        "fsd/no-global-store-imports": [
+          "error",
+          { allowedPaths: ["selectors"] },
+        ],
+      },
+    );
+
+    expect(messages).toEqual([]);
+  });
+
+  it("supports custom forbiddenPaths lists", async () => {
+    const messages = await lintText(
+      `
+        import { state } from "@/state/global";
+        import { otherState } from "@/services/data";
+      `,
+      "src/features/auth/ui/LoginForm.tsx",
+      {
+        "fsd/no-global-store-imports": [
+          "error",
+          { forbiddenPaths: ["/state/"] },
+        ],
+      },
+    );
+
+    expect(ruleIds(messages)).toEqual(["fsd/no-global-store-imports"]);
+  });
+
+  it("skips test files by default", async () => {
+    const messages = await lintText(
+      'import { state } from "@/app/store/global";',
+      "src/features/auth/model/session.test.ts",
+      {
+        "fsd/no-global-store-imports": "error",
+      },
+    );
+
+    expect(messages).toEqual([]);
+  });
+});
+
+describe("FSD 2.x — fs-resolver edge cases", () => {
+  it("falls back to legacy parsing when fs cannot resolve the path", async () => {
+    const messages = await lintText(
+      'import { thing } from "@features/profile/model/service";',
+      "src/features/auth/ui/LoginForm.tsx",
+      {
+        "fsd/no-cross-slice-dependency": "error",
+      },
+    );
+
+    expect(messageIds(messages)).toEqual(["noFeatureDependency"]);
+  });
+
+  it("does not crash when filePath is outside the configured rootPath", async () => {
+    const messages = await lintText(
+      'import React from "react";',
+      "outside/scope/file.ts",
+      {
+        "fsd/forbidden-imports": "error",
+        "fsd/no-cross-slice-dependency": "error",
+        "fsd/no-public-api-sidestep": "error",
+      },
+    );
+
+    expect(messages).toEqual([]);
+  });
+
+  it("does not flag relative imports that stay inside a slice", async () => {
+    const messages = await lintText(
+      'import { session } from "./session";',
+      "tests/fixtures/resolve-project/src/features/auth/model/index.ts",
+      {
+        "fsd/no-cross-slice-dependency": ["error", fixtureRoot],
+        "fsd/forbidden-imports": ["error", fixtureRoot],
+      },
+    );
+
+    expect(messages).toEqual([]);
+  });
+
+  it("does not break when an explicit tsconfigPath is missing", async () => {
+    const messages = await lintText(
+      'import { Button } from "@shared/ui/Button";',
+      "src/features/auth/ui/LoginForm.tsx",
+      {
+        "fsd/forbidden-imports": [
+          "error",
+          { tsconfigPath: "tests/fixtures/does-not-exist.json" },
+        ],
+      },
+    );
+
+    expect(messages).toEqual([]);
+  });
+});
+
+describe("FSD 2.x — index file extension matrix for public API", () => {
+  it.each([
+    ["index.ts", "@features/auth/index.ts"],
+    ["index.tsx", "@features/auth/index.tsx"],
+    ["index.js", "@features/auth/index.js"],
+    ["index.jsx", "@features/auth/index.jsx"],
+    ["bare slice", "@features/auth"],
+  ])("treats %s as the slice public API", async (_name, importPath) => {
+    const messages = await lintText(
+      `import { x } from "${importPath}";`,
+      "src/pages/articles/ui/articles-page.tsx",
+      {
+        "fsd/no-public-api-sidestep": [
+          "error",
+          { publicApi: { allowSegmentImports: false } },
+        ],
+      },
+    );
+
+    expect(messages).toEqual([]);
+  });
+});
+
+describe("FSD 2.x — allowedToImport overrides", () => {
+  it("respects a custom allowedToImport list that loosens defaults", async () => {
+    const messages = await lintText(
+      'import { LoginForm } from "@features/auth";',
+      "src/entities/user/ui/UserCard.tsx",
+      {
+        "fsd/forbidden-imports": [
+          "error",
+          {
+            layers: {
+              entities: {
+                allowedToImport: ["features", "shared"],
+              },
+            },
+          },
+        ],
+      },
+    );
+
+    expect(messages).toEqual([]);
+  });
+
+  it("respects a custom allowedToImport list that tightens defaults", async () => {
+    const messages = await lintText(
+      'import { Button } from "@shared/ui/Button";',
+      "src/entities/user/model/user.ts",
+      {
+        "fsd/forbidden-imports": [
+          "error",
+          {
+            layers: {
+              entities: {
+                allowedToImport: [],
+              },
+            },
+          },
+        ],
+      },
+    );
+
+    expect(ruleIds(messages)).toEqual(["fsd/forbidden-imports"]);
+  });
+});

--- a/tests/fsd-latest-rules.test.js
+++ b/tests/fsd-latest-rules.test.js
@@ -1,0 +1,245 @@
+import { ESLint } from "eslint";
+import tsParser from "@typescript-eslint/parser";
+import { describe, expect, it } from "vitest";
+
+import fsdPlugin from "../src/index.js";
+
+const fixtureOptions = {
+  rootPath: "/tests/fixtures/resolve-project/src/",
+};
+
+const allArchitecturalRules = {
+  "fsd/forbidden-imports": ["error", fixtureOptions],
+  "fsd/no-cross-slice-dependency": ["error", fixtureOptions],
+  "fsd/no-public-api-sidestep": ["error", fixtureOptions],
+};
+
+function createEslint(rules) {
+  return new ESLint({
+    overrideConfigFile: true,
+    ignore: false,
+    overrideConfig: [
+      {
+        files: ["**/*.ts", "**/*.tsx"],
+        languageOptions: {
+          parser: tsParser,
+          ecmaVersion: 2022,
+          sourceType: "module",
+        },
+        plugins: {
+          fsd: fsdPlugin,
+        },
+        rules,
+      },
+    ],
+  });
+}
+
+async function lintText(code, filePath, rules = allArchitecturalRules) {
+  const eslint = createEslint(rules);
+  const [result] = await eslint.lintText(code, { filePath });
+
+  return result.messages;
+}
+
+function ruleIds(messages) {
+  return messages.map((message) => message.ruleId);
+}
+
+describe("latest FSD architectural rules", () => {
+  it.each([
+    [
+      "app can import pages",
+      'import { ArticlesLayout } from "@articles/ui/articles-page";',
+      "tests/fixtures/resolve-project/src/app/providers/AppProvider.tsx",
+      [],
+    ],
+    [
+      "pages can import features",
+      'import { authPublicApi } from "@auth";',
+      "tests/fixtures/resolve-project/src/pages/articles/ui/articles-page.tsx",
+      [],
+    ],
+    [
+      "features can import entities",
+      'import { userPublicApi } from "@user";',
+      "tests/fixtures/resolve-project/src/features/auth/model/session.ts",
+      [],
+    ],
+    [
+      "entities cannot import features",
+      'import { authPublicApi } from "@auth";',
+      "tests/fixtures/resolve-project/src/entities/user/model/session.ts",
+      ["fsd/forbidden-imports"],
+    ],
+    [
+      "shared cannot import entities",
+      'import { userPublicApi } from "@user";',
+      "tests/fixtures/resolve-project/src/shared/lib/date.ts",
+      ["fsd/forbidden-imports"],
+    ],
+    [
+      "features cannot import widgets",
+      'import { Header } from "@/widgets/header";',
+      "tests/fixtures/resolve-project/src/features/auth/model/session.ts",
+      ["fsd/forbidden-imports"],
+    ],
+  ])("%s", async (_name, code, filePath, expectedRuleIds) => {
+    const messages = await lintText(code, filePath, {
+      "fsd/forbidden-imports": [
+        "error",
+        {
+          ...fixtureOptions,
+          alias: {
+            value: "@",
+            withSlash: true,
+          },
+        },
+      ],
+    });
+
+    expect(ruleIds(messages)).toEqual(expectedRuleIds);
+  });
+
+  it.each([
+    [
+      "pages cross-slice is blocked",
+      'import { ProfilePage } from "@profile/ui/profile-page";',
+      "tests/fixtures/resolve-project/src/pages/articles/ui/articles-page.tsx",
+      ["fsd/forbidden-imports", "fsd/no-cross-slice-dependency"],
+    ],
+    [
+      "features cross-slice is blocked",
+      'import { authSession } from "@auth/model/session";',
+      "tests/fixtures/resolve-project/src/features/profile/ui/ProfilePage.tsx",
+      [
+        "fsd/forbidden-imports",
+        "fsd/no-cross-slice-dependency",
+        "fsd/no-public-api-sidestep",
+      ],
+    ],
+    [
+      "same page slice hidden alias is allowed",
+      'import { articleSections } from "@articles/api/queries";',
+      "tests/fixtures/resolve-project/src/pages/articles/ui/articles-page.tsx",
+      [],
+    ],
+  ])("%s", async (_name, code, filePath, expectedRuleIds) => {
+    const messages = await lintText(code, filePath);
+
+    expect(ruleIds(messages)).toEqual(expectedRuleIds);
+  });
+
+  it("does not treat app and shared internals as cross-slice imports", async () => {
+    await expect(
+      lintText(
+        'import { initProviders } from "./providers/init";',
+        "tests/fixtures/resolve-project/src/app/App.tsx",
+      ),
+    ).resolves.toEqual([]);
+
+    await expect(
+      lintText(
+        'import { formatDate } from "../lib/date";',
+        "tests/fixtures/resolve-project/src/shared/ui/button/index.ts",
+      ),
+    ).resolves.toEqual([]);
+  });
+
+  it("allows entities @x public APIs only for the declared consumer slice", async () => {
+    await expect(
+      lintText(
+        'import type { SongForArtist } from "@song/@x/artist";',
+        "tests/fixtures/resolve-project/src/entities/artist/model/artist.ts",
+      ),
+    ).resolves.toEqual([]);
+
+    await expect(
+      lintText(
+        'import type { SongForArtist } from "@song-for-artist";',
+        "tests/fixtures/resolve-project/src/entities/artist/model/artist.ts",
+      ),
+    ).resolves.toEqual([]);
+
+    const wrongConsumerMessages = await lintText(
+      'import type { SongForArtist } from "@song/@x/artist";',
+      "tests/fixtures/resolve-project/src/entities/playlist/model/playlist.ts",
+    );
+
+    expect(ruleIds(wrongConsumerMessages)).toEqual([
+      "fsd/forbidden-imports",
+      "fsd/no-cross-slice-dependency",
+      "fsd/no-public-api-sidestep",
+    ]);
+  });
+
+  it("keeps non-@x entity internals private across entity slices", async () => {
+    const messages = await lintText(
+      'import { songInternal } from "@song/model/song";',
+      "tests/fixtures/resolve-project/src/entities/artist/model/artist.ts",
+    );
+
+    expect(ruleIds(messages)).toEqual([
+      "fsd/forbidden-imports",
+      "fsd/no-cross-slice-dependency",
+      "fsd/no-public-api-sidestep",
+    ]);
+  });
+
+  it("does not let higher layers use an entities @x API as a general public API", async () => {
+    const messages = await lintText(
+      'import type { SongForArtist } from "@song/@x/artist";',
+      "tests/fixtures/resolve-project/src/features/auth/model/session.ts",
+    );
+
+    expect(ruleIds(messages)).toEqual(["fsd/no-public-api-sidestep"]);
+  });
+
+  it("keeps public API imports valid when tsconfig paths point to index files", async () => {
+    await expect(
+      lintText(
+        'import { songPublicApi } from "@song";',
+        "tests/fixtures/resolve-project/src/features/auth/model/session.ts",
+      ),
+    ).resolves.toEqual([]);
+
+    await expect(
+      lintText(
+        'import { userPublicApi } from "@user";',
+        "tests/fixtures/resolve-project/src/pages/articles/ui/articles-page.tsx",
+      ),
+    ).resolves.toEqual([]);
+  });
+
+  it("falls back to legacy FSD path parsing when files are unresolved", async () => {
+    const messages = await lintText(
+      'import { profileService } from "@features/profile/model/service";',
+      "src/features/auth/ui/LoginForm.tsx",
+      {
+        "fsd/forbidden-imports": "error",
+        "fsd/no-cross-slice-dependency": "error",
+        "fsd/no-public-api-sidestep": "error",
+      },
+    );
+
+    expect(ruleIds(messages)).toEqual([
+      "fsd/forbidden-imports",
+      "fsd/no-cross-slice-dependency",
+      "fsd/no-public-api-sidestep",
+    ]);
+  });
+
+  it("handles dynamic imports through the same resolver path", async () => {
+    const messages = await lintText(
+      'const profile = await import("@profile/ui/profile-page");',
+      "tests/fixtures/resolve-project/src/pages/articles/ui/articles-page.tsx",
+      {
+        "fsd/no-cross-slice-dependency": ["error", fixtureOptions],
+      },
+    );
+
+    expect(messages.map((message) => message.messageId)).toEqual([
+      "noSliceDependency",
+    ]);
+  });
+});

--- a/tests/import-resolver.test.js
+++ b/tests/import-resolver.test.js
@@ -1,0 +1,292 @@
+import { ESLint } from "eslint";
+import tsParser from "@typescript-eslint/parser";
+import { describe, expect, it } from "vitest";
+
+import fsdPlugin from "../src/index.js";
+
+const fixtureOptions = {
+  rootPath: "/tests/fixtures/resolve-project/src/",
+};
+
+const explicitTsconfigOptions = {
+  ...fixtureOptions,
+  tsconfigPath: "tests/fixtures/explicit-tsconfig/tsconfig.json",
+};
+
+const articlePageFile =
+  "tests/fixtures/resolve-project/src/pages/articles/ui/articles-pending-page.tsx";
+
+const profileFeatureFile =
+  "tests/fixtures/resolve-project/src/features/profile/ui/ProfilePage.tsx";
+
+const userEntityFile =
+  "tests/fixtures/resolve-project/src/entities/user/model/session.ts";
+
+function createEslint(rules) {
+  return new ESLint({
+    overrideConfigFile: true,
+    ignore: false,
+    overrideConfig: [
+      {
+        files: ["**/*.ts", "**/*.tsx"],
+        languageOptions: {
+          parser: tsParser,
+          ecmaVersion: 2022,
+          sourceType: "module",
+        },
+        plugins: {
+          fsd: fsdPlugin,
+        },
+        rules,
+      },
+    ],
+  });
+}
+
+async function lintText(code, filePath, rules) {
+  const eslint = createEslint(rules);
+  const [result] = await eslint.lintText(code, { filePath });
+
+  return result.messages;
+}
+
+describe("filesystem import resolver", () => {
+  it("resolves configured root aliases without tsconfig paths", async () => {
+    const messages = await lintText(
+      'import { ArticlesLayout } from "@/pages/articles/ui/articles-page";',
+      articlePageFile,
+      {
+        "fsd/forbidden-imports": [
+          "error",
+          {
+            ...fixtureOptions,
+            alias: {
+              value: "@",
+              withSlash: true,
+            },
+          },
+        ],
+      },
+    );
+
+    expect(messages).toEqual([]);
+  });
+
+  it("resolves omitted extensions to concrete TypeScript and TSX files", async () => {
+    await expect(
+      lintText(
+        'import { articleSections } from "@articles/api/queries";',
+        articlePageFile,
+        {
+          "fsd/forbidden-imports": ["error", fixtureOptions],
+        },
+      ),
+    ).resolves.toEqual([]);
+
+    await expect(
+      lintText(
+        'import { ArticlesLayout } from "@articles/ui/articles-page";',
+        articlePageFile,
+        {
+          "fsd/forbidden-imports": ["error", fixtureOptions],
+        },
+      ),
+    ).resolves.toEqual([]);
+  });
+
+  it("resolves directory index files from aliases", async () => {
+    await expect(
+      lintText(
+        'import { ArticlesLayout } from "@multi/articles";',
+        articlePageFile,
+        {
+          "fsd/forbidden-imports": ["error", fixtureOptions],
+        },
+      ),
+    ).resolves.toEqual([]);
+
+    await expect(
+      lintText(
+        'import { ArticlesLayout } from "@page/articles";',
+        articlePageFile,
+        {
+          "fsd/forbidden-imports": ["error", fixtureOptions],
+        },
+      ),
+    ).resolves.toEqual([]);
+  });
+
+  it("falls through multiple tsconfig path targets until an existing file is found", async () => {
+    const messages = await lintText(
+      'import { ProfilePage } from "@multi/profile/ui/profile-page";',
+      articlePageFile,
+      {
+        "fsd/forbidden-imports": ["error", fixtureOptions],
+        "fsd/no-cross-slice-dependency": ["error", fixtureOptions],
+      },
+    );
+
+    expect(messages.map((message) => message.ruleId)).toEqual([
+      "fsd/forbidden-imports",
+      "fsd/no-cross-slice-dependency",
+    ]);
+  });
+
+  it("uses baseUrl resolution when no paths pattern matches", async () => {
+    await expect(
+      lintText(
+        'import { userPublicApi } from "src/entities/user";',
+        profileFeatureFile,
+        {
+          "fsd/forbidden-imports": ["error", fixtureOptions],
+          "fsd/no-public-api-sidestep": ["error", fixtureOptions],
+        },
+      ),
+    ).resolves.toEqual([]);
+  });
+
+  it("resolves shared segment indexes when shared public API enforcement is enabled", async () => {
+    await expect(
+      lintText('import { Button } from "@ui-button";', articlePageFile, {
+        "fsd/no-public-api-sidestep": [
+          "error",
+          {
+            ...fixtureOptions,
+            publicApi: {
+              enforceShared: true,
+            },
+          },
+        ],
+      }),
+    ).resolves.toEqual([]);
+  });
+
+  it("allows same-slice imports through tsconfig path aliases", async () => {
+    const messages = await lintText(
+      `
+        import { articleSections } from "@articles/api/queries";
+        import { ArticlesLayout } from "@articles/ui/articles-page";
+      `,
+      articlePageFile,
+      {
+        "fsd/forbidden-imports": ["error", fixtureOptions],
+        "fsd/no-cross-slice-dependency": ["error", fixtureOptions],
+        "fsd/no-public-api-sidestep": [
+          "error",
+          {
+            ...fixtureOptions,
+            publicApi: {
+              enforceForLayers: ["pages"],
+            },
+          },
+        ],
+      },
+    );
+
+    expect(messages).toEqual([]);
+  });
+
+  it("keeps reporting cross-slice imports resolved through tsconfig path aliases", async () => {
+    const messages = await lintText(
+      'import { ProfilePage } from "@profile/ui/profile-page";',
+      articlePageFile,
+      {
+        "fsd/forbidden-imports": ["error", fixtureOptions],
+        "fsd/no-cross-slice-dependency": ["error", fixtureOptions],
+      },
+    );
+
+    expect(messages.map((message) => message.ruleId)).toEqual([
+      "fsd/forbidden-imports",
+      "fsd/no-cross-slice-dependency",
+    ]);
+  });
+
+  it("reports hidden higher-layer imports resolved through tsconfig path aliases", async () => {
+    const messages = await lintText(
+      'import { authPublicApi } from "@auth";',
+      userEntityFile,
+      {
+        "fsd/forbidden-imports": ["error", fixtureOptions],
+      },
+    );
+
+    expect(messages.map((message) => message.ruleId)).toEqual([
+      "fsd/forbidden-imports",
+    ]);
+  });
+
+  it("uses resolved files when checking public API sidesteps", async () => {
+    await expect(
+      lintText('import { authPublicApi } from "@auth";', profileFeatureFile, {
+        "fsd/no-public-api-sidestep": ["error", fixtureOptions],
+      }),
+    ).resolves.toEqual([]);
+
+    await expect(
+      lintText(
+        'import { authSession } from "@auth/model/session";',
+        profileFeatureFile,
+        {
+          "fsd/no-public-api-sidestep": ["error", fixtureOptions],
+        },
+      ),
+    ).resolves.toHaveLength(1);
+  });
+
+  it("uses resolved files when checking cross-slice dependencies", async () => {
+    const messages = await lintText(
+      'import { authSession } from "@auth/model/session";',
+      profileFeatureFile,
+      {
+        "fsd/no-cross-slice-dependency": ["error", fixtureOptions],
+      },
+    );
+
+    expect(messages.map((message) => message.messageId)).toEqual([
+      "noFeatureDependency",
+    ]);
+  });
+
+  it("uses resolved layers for ordered imports", async () => {
+    const messages = await lintText(
+      `
+        import { authPublicApi } from "@auth";
+        import { ArticlesLayout } from "@articles/ui/articles-page";
+      `,
+      articlePageFile,
+      {
+        "fsd/ordered-imports": ["error", fixtureOptions],
+      },
+    );
+
+    expect(messages.map((message) => message.ruleId)).toEqual([
+      "fsd/ordered-imports",
+    ]);
+  });
+
+  it("supports explicit tsconfigPath when the nearest config does not contain the alias", async () => {
+    const messages = await lintText(
+      'import { ArticlesLayout } from "@explicit-articles/ui/articles-page";',
+      articlePageFile,
+      {
+        "fsd/forbidden-imports": ["error", explicitTsconfigOptions],
+      },
+    );
+
+    expect(messages).toEqual([]);
+  });
+
+  it("accepts tsconfigPath in rules that share common FSD options", async () => {
+    const messages = await lintText(
+      'import { articleSections } from "../api/queries";',
+      articlePageFile,
+      {
+        "fsd/no-relative-imports": ["error", explicitTsconfigOptions],
+        "fsd/no-ui-in-business-logic": ["error", explicitTsconfigOptions],
+      },
+    );
+
+    expect(messages).toEqual([]);
+  });
+});

--- a/tests/no-public-api-sidestep-options.test.js
+++ b/tests/no-public-api-sidestep-options.test.js
@@ -27,10 +27,14 @@ function createEslint(ruleOptions = {}) {
   });
 }
 
-async function lintText(code, ruleOptions) {
+async function lintText(
+  code,
+  ruleOptions,
+  filePath = "src/features/profile/model/profile.ts",
+) {
   const eslint = createEslint(ruleOptions);
   const [result] = await eslint.lintText(code, {
-    filePath: "src/features/profile/model/profile.ts",
+    filePath,
   });
 
   return result.messages;
@@ -47,6 +51,51 @@ describe("no-public-api-sidestep publicApi options", () => {
         import { userModel } from "@entities/user/model";
         import { userUi } from "@entities/user/ui";
       `,
+    );
+
+    expect(messages).toEqual([]);
+  });
+
+  it("allows same-slice aliased internal imports", async () => {
+    const messages = await lintText(
+      `
+        import { authSession } from "@features/auth/model/session";
+        import { LoginFormView } from "@features/auth/ui/LoginFormView";
+      `,
+      undefined,
+      "src/features/auth/ui/LoginForm.tsx",
+    );
+
+    expect(messages).toEqual([]);
+  });
+
+  it("keeps reporting cross-slice aliased internal imports", async () => {
+    const messages = await lintText(
+      'import { authSession } from "@features/auth/model/session";',
+      undefined,
+      "src/features/profile/ui/ProfilePage.tsx",
+    );
+
+    expect(getMessageIds(messages)).toEqual(["noDirectImport"]);
+  });
+
+  it("allows same-slice aliased internal imports when pages public APIs are enforced", async () => {
+    const messages = await lintText(
+      `
+        import { articleSections } from "@/pages/articles/api/queries";
+        import { ArticlesLayout } from "@/pages/articles/ui/articles-page";
+      `,
+      {
+        rootPath: "/apps/web/src/",
+        alias: {
+          value: "@",
+          withSlash: true,
+        },
+        publicApi: {
+          enforceForLayers: ["pages"],
+        },
+      },
+      "apps/web/src/pages/articles/ui/articles-pending-page.tsx",
     );
 
     expect(messages).toEqual([]);

--- a/tests/root-path.test.js
+++ b/tests/root-path.test.js
@@ -43,6 +43,44 @@ describe("rootPath support", () => {
     expect(messages[0].ruleId).toBe("fsd/forbidden-imports");
   });
 
+  it("allows same-slice aliased imports for forbidden-imports", async () => {
+    const messages = await lintText(
+      "fsd/forbidden-imports",
+      {
+        rootPath: "/apps/web/src/",
+        alias: {
+          value: "@",
+          withSlash: true,
+        },
+      },
+      `
+        import { articleSections } from "@/pages/articles/api/queries";
+        import { ArticlesLayout } from "@/pages/articles/ui/articles-page";
+      `,
+      "apps/web/src/pages/articles/ui/articles-pending-page.ts",
+    );
+
+    expect(messages).toHaveLength(0);
+  });
+
+  it("still flags cross-slice same-layer aliased imports for forbidden-imports", async () => {
+    const messages = await lintText(
+      "fsd/forbidden-imports",
+      {
+        rootPath: "/apps/web/src/",
+        alias: {
+          value: "@",
+          withSlash: true,
+        },
+      },
+      'import { ProfilePage } from "@/pages/profile/ui/profile-page";',
+      "apps/web/src/pages/articles/ui/articles-pending-page.ts",
+    );
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0].ruleId).toBe("fsd/forbidden-imports");
+  });
+
   it("keeps same-slice imports valid for no-cross-slice-dependency", async () => {
     const messages = await lintText(
       "fsd/no-cross-slice-dependency",


### PR DESCRIPTION
## Description
Closes #26.

The plugin previously inferred FSD layer and slice information from the literal text of an import path. With path aliases, this produced false positives such as `@/pages/articles/api/queries` being flagged as a cross-slice import even though both the importer and the target lived in `pages/articles`.

This PR introduces a filesystem-aware import resolver in `path-utils` that consults `tsconfig.json` / `jsconfig.json` `paths` and `baseUrl` and the configured FSD `alias` before falling back to the legacy string parser. Layer and slice info is now derived from the resolved file path so same-slice aliased imports are correctly recognized. Rules also share a single `getImportTargetInfo` helper, and `forbidden-imports` plus `no-public-api-sidestep` short-circuit when the consumer and target slices match (skipped for `app`/`shared`, which have no slices). A new optional `tsconfigPath` option lets users point rules at an explicit config when the nearest one is not appropriate.

This change covers behavior, documentation, and a large expansion of the test suite.

## Changes
- Add `resolveImportPath` and `getImportTargetInfo` in `src/utils/path-utils.js`. They resolve through tsconfig paths, baseUrl, configured alias, relative paths, and index files, with `tsConfigCache` and `importResolveCache` for performance.
- Add `tsconfigPath` to defaults and merging in `src/utils/config-utils.js`, and to the schema of every rule that already accepted `rootPath`.
- Switch `fsd/forbidden-imports`, `fsd/no-cross-slice-dependency`, `fsd/no-public-api-sidestep`, `fsd/no-relative-imports`, `fsd/no-ui-in-business-logic`, and `fsd/ordered-imports` to use `getImportTargetInfo`.
- Skip same-slice imports in `fsd/forbidden-imports` and `fsd/no-public-api-sidestep` when the importer and target are in the same slice. `app` and `shared` are exempt from the slice check.
- Add a layer-segment guard in `fsd/no-public-api-sidestep` so an alias whose first segment does not match the resolved layer no longer falsely passes the public API check.
- Add a resolved-path public API check in `fsd/no-public-api-sidestep` that uses the real file path when available.
- Add `tests/fsd-comprehensive.test.js` with 102 cases covering layer-pair matrix, segment access, public API variations, alias variations, numeric folder prefixes, ignore patterns, test-file exemption, import expression variations, allowedToImport overrides, and resolver edge cases.
- Add `tests/fsd-latest-rules.test.js`, `tests/import-resolver.test.js`, and `tests/forbidden-imports-same-slice.test.js` for FSD 2.x patterns including `@x` cross-imports, explicit tsconfigPath, and the issue #26 regression cases.
- Add `tests/fixtures/resolve-project/` and `tests/fixtures/explicit-tsconfig/` so the resolver can run against a real on-disk project tree.
- Document filesystem-aware resolution and `tsconfigPath` in the English and Korean READMEs.

## Before / After
| Case | Before | After |
| --- | --- | --- |
| Same-slice import via tsconfig path (`@articles/api/queries` from `pages/articles/ui/...`) | Reported as cross-slice | Resolved through tsconfig and accepted |
| Same-slice import via configured alias (`@/pages/articles/...` from `pages/articles/...`) | Reported as cross-slice | Slice match detected and accepted |
| Public API check on aliased path | Compared first import segment to layer | Verifies the resolved file's layer first, then the segment count |
| Cross-slice imports (different slices in same layer) | Flagged | Still flagged |
| Layer-direction violations | Flagged | Still flagged |
| Bundler-only aliases that don't resolve to a real file | Flagged via legacy string parsing | Same legacy parsing as fallback |
| Test count | 70 tests across 10 files | 192 tests across 12 files |

## Type of Change
- [x] Documentation
- [x] Bug fix
- [x] Feature
- [x] Refactoring
- [ ] Other (describe below)

## How to Test
- `npm run format:check`
- `npm run lint`
- `npm run lint:test-project`
- `npm run lint:test-project-next`
- `npm test` — 12 files, 192 tests

## Additional Information
- Resolution falls back to legacy string parsing whenever a target file cannot be located, so projects that rely on bundler-only aliases continue to work without changes.
- The new `tsConfigCache` and `importResolveCache` are module-scoped. They keep one-shot ESLint runs fast. In long-running daemons the caches do not currently observe tsconfig changes; that is acceptable for typical CI usage and can be revisited if it becomes a problem.
- `RuleTester` integration in `tests/rules/*.js` is unrelated to this change but was confirmed to be silently no-op during this work. A separate PR addresses two real rule bugs surfaced while building the new test coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)