### PR TITLE
fix: repair no-ui-in-business-logic crash and dynamic-import dispatch

### DIFF
--- a/src/rules/no-relative-imports.js
+++ b/src/rules/no-relative-imports.js
@@ -163,83 +163,59 @@ export default {
       return currentLayer === importLayer && currentSlice === importSlice;
     }
 
+    function checkImport(node, importPath, { isTypeImport }) {
+      if (typeof importPath !== "string") {
+        return;
+      }
+
+      if (!isRelativePath(importPath)) {
+        return;
+      }
+
+      if (isTestFile(context.filename, config.testFilesPatterns)) {
+        return;
+      }
+
+      const isIgnored = config.ignoreImportPatterns.some((pattern) => {
+        const regex = new RegExp(pattern);
+        return regex.test(importPath);
+      });
+
+      if (isIgnored) {
+        return;
+      }
+
+      if (allowTypeImports && isTypeImport) {
+        return;
+      }
+
+      if (allowSameSlice && isSameSlice(importPath, context.filename)) {
+        return;
+      }
+
+      context.report({
+        node,
+        messageId: "noRelativeImport",
+      });
+    }
+
     return {
       ImportDeclaration(node) {
-        const importPath = node.source.value;
-
-        // Skip if not a relative import
-        if (!isRelativePath(importPath)) {
-          return;
-        }
-
-        // Skip test files
-        if (isTestFile(context.filename, config.testFilesPatterns)) {
-          return;
-        }
-
-        // Check for ignored patterns
-        const isIgnored = config.ignoreImportPatterns.some((pattern) => {
-          const regex = new RegExp(pattern);
-          return regex.test(importPath);
-        });
-
-        if (isIgnored) {
-          return;
-        }
-
-        // Skip type-only imports if configured
-        if (allowTypeImports && node.importKind === "type") {
-          return;
-        }
-
-        // Skip same slice imports if configured
-        if (allowSameSlice && isSameSlice(importPath, context.filename)) {
-          return;
-        }
-
-        context.report({
-          node,
-          messageId: "noRelativeImport",
+        checkImport(node, node.source.value, {
+          isTypeImport: node.importKind === "type",
         });
       },
       CallExpression(node) {
-        // Handle dynamic imports
         if (node.callee.type === "Import") {
-          const importPath = node.arguments[0].value;
-
-          // Skip if not a relative import
-          if (!isRelativePath(importPath)) {
-            return;
-          }
-
-          // Skip test files
-          if (isTestFile(context.filename, config.testFilesPatterns)) {
-            return;
-          }
-
-          // Check for ignored patterns
-          const isIgnored = config.ignoreImportPatterns.some((pattern) => {
-            const regex = new RegExp(pattern);
-            return regex.test(importPath);
-          });
-
-          if (isIgnored) {
-            return;
-          }
-
-          // For dynamic imports, we can't check if it's a type import
-          // as that information is not available at parse time
-
-          // Skip same slice imports if configured
-          if (allowSameSlice && isSameSlice(importPath, context.filename)) {
-            return;
-          }
-
-          context.report({
-            node,
-            messageId: "noRelativeImport",
+          checkImport(node, node.arguments[0]?.value, {
+            isTypeImport: false,
           });
         }
+      },
+      ImportExpression(node) {
+        checkImport(node, node.source?.value, {
+          isTypeImport: false,
+        });
       },
     };
   },

--- a/src/rules/no-ui-in-business-logic.js
+++ b/src/rules/no-ui-in-business-logic.js
@@ -104,107 +104,73 @@ export default {
     const allowTypeImports = options.allowTypeImports || false;
 
     // Define UI and business logic layers
-    const uiLayers = new Set(options.uiLayers || ["ui", "widgets", "features"]);
+    const uiLayers = options.uiLayers || ["ui", "widgets", "features"];
     const businessLogicLayers = new Set(
       options.businessLogicLayers || ["model", "api", "lib"],
     );
 
+    function checkImport(node, importPath, { isTypeImport }) {
+      if (typeof importPath !== "string") {
+        return;
+      }
+
+      const filePath = normalizePath(context.filename);
+
+      if (isTestFile(filePath, config.testFilesPatterns)) {
+        return;
+      }
+
+      const isIgnored = config.ignoreImportPatterns.some((pattern) => {
+        const regex = new RegExp(pattern);
+        return regex.test(importPath);
+      });
+
+      if (isIgnored) {
+        return;
+      }
+
+      const fromLayer = extractLayerFromPath(filePath, config);
+      if (!fromLayer) {
+        return;
+      }
+
+      if (!businessLogicLayers.has(fromLayer)) {
+        return;
+      }
+
+      if (allowTypeImports && isTypeImport) {
+        return;
+      }
+
+      const isUiImport = uiLayers.some((layer) =>
+        importPath.includes(`/${layer}/`),
+      );
+
+      if (isUiImport) {
+        context.report({
+          node,
+          messageId: "noUiInBusinessLogic",
+        });
+      }
+    }
+
     return {
       ImportDeclaration(node) {
-        const filePath = normalizePath(context.filename);
-        const importPath = node.source.value;
-
-        // Skip test files
-        if (isTestFile(filePath, config.testFilesPatterns)) {
-          return;
-        }
-
-        // Check for ignored patterns
-        const isIgnored = config.ignoreImportPatterns.some((pattern) => {
-          const regex = new RegExp(pattern);
-          return regex.test(importPath);
+        checkImport(node, node.source.value, {
+          isTypeImport: node.importKind === "type",
         });
-
-        if (isIgnored) {
-          return;
-        }
-
-        // Extract current file's layer
-        const fromLayer = extractLayerFromPath(filePath, config);
-        if (!fromLayer) {
-          return;
-        }
-
-        // Check if current file is in a business logic layer
-        const isBusinessLogicLayer = businessLogicLayers.has(fromLayer);
-        if (!isBusinessLogicLayer) {
-          return;
-        }
-
-        // Skip type-only imports if configured
-        if (allowTypeImports && node.importKind === "type") {
-          return;
-        }
-
-        // Check if import is from a UI layer
-        const isUiImport = uiLayers.some((layer) =>
-          importPath.includes(`/${layer}/`),
-        );
-        if (isUiImport) {
-          context.report({
-            node,
-            messageId: "noUiInBusinessLogic",
+      },
+      CallExpression(node) {
+        if (node.callee.type === "Import") {
+          checkImport(node, node.arguments[0]?.value, {
+            isTypeImport: false,
           });
         }
       },
-      CallExpression(node) {
-        // Handle dynamic imports
-        if (node.callee.type === "Import") {
-          const filePath = normalizePath(context.filename);
-          const importPath = node.arguments[0].value;
-
-          // Skip test files
-          if (isTestFile(filePath, config.testFilesPatterns)) {
-            return;
-          }
-
-          // Check for ignored patterns
-          const isIgnored = config.ignoreImportPatterns.some((pattern) => {
-            const regex = new RegExp(pattern);
-            return regex.test(importPath);
-          });
-
-          if (isIgnored) {
-            return;
-          }
-
-          // Extract current file's layer
-          const fromLayer = extractLayerFromPath(filePath, config);
-          if (!fromLayer) {
-            return;
-          }
-
-          // Check if current file is in a business logic layer
-          const isBusinessLogicLayer = businessLogicLayers.has(fromLayer);
-          if (!isBusinessLogicLayer) {
-            return;
-          }
-
-          // For dynamic imports, we can't check if it's a type import
-          // as that information is not available at parse time
-          // So we'll always report UI imports in dynamic imports
-
-          // Check if import is from a UI layer
-          const isUiImport = uiLayers.some((layer) =>
-            importPath.includes(`/${layer}/`),
-          );
-          if (isUiImport) {
-            context.report({
-              node,
-              messageId: "noUiInBusinessLogic",
-            });
-          }
-        }
+      ImportExpression(node) {
+        checkImport(node, node.source?.value, {
+          isTypeImport: false,
+        });
       },
     };
   },

--- a/tests/fsd-comprehensive.test.js
+++ b/tests/fsd-comprehensive.test.js
@@ -803,12 +803,55 @@ describe("FSD 2.x — no-relative-imports", () => {
 });
 
 describe("FSD 2.x — no-ui-in-business-logic", () => {
+  const fsdBusinessLayers = {
+    businessLogicLayers: ["entities", "features", "widgets"],
+  };
+
   it("does not flag imports when the file's layer is outside default business-logic layers", async () => {
     const messages = await lintText(
       'import { Button } from "@shared/ui/Button";',
       "src/entities/user/model/user.ts",
       {
         "fsd/no-ui-in-business-logic": "error",
+      },
+    );
+
+    expect(messages).toEqual([]);
+  });
+
+  it("blocks ui-segment paths imported into entities model", async () => {
+    const messages = await lintText(
+      'import { Button } from "@shared/ui/Button";',
+      "src/entities/user/model/user.ts",
+      {
+        "fsd/no-ui-in-business-logic": ["error", fsdBusinessLayers],
+      },
+    );
+
+    expect(ruleIds(messages)).toEqual(["fsd/no-ui-in-business-logic"]);
+  });
+
+  it("blocks widget paths imported into a features api segment", async () => {
+    const messages = await lintText(
+      'import { Header } from "@app/widgets/Header";',
+      "src/features/auth/api/login.ts",
+      {
+        "fsd/no-ui-in-business-logic": ["error", fsdBusinessLayers],
+      },
+    );
+
+    expect(ruleIds(messages)).toEqual(["fsd/no-ui-in-business-logic"]);
+  });
+
+  it("can allow type-only UI imports inside business logic", async () => {
+    const messages = await lintText(
+      'import type { ButtonProps } from "@shared/ui/Button";',
+      "src/entities/user/model/user.ts",
+      {
+        "fsd/no-ui-in-business-logic": [
+          "error",
+          { ...fsdBusinessLayers, allowTypeImports: true },
+        ],
       },
     );
 
@@ -852,6 +895,33 @@ describe("FSD 2.x — no-ui-in-business-logic", () => {
     );
 
     expect(messages).toEqual([]);
+  });
+
+  it("flags dynamic UI imports inside business logic", async () => {
+    const messages = await lintText(
+      'const m = await import("@features/auth/ui/LoginForm");',
+      "src/entities/user/model/user.ts",
+      {
+        "fsd/no-ui-in-business-logic": ["error", fsdBusinessLayers],
+      },
+    );
+
+    expect(ruleIds(messages)).toEqual(["fsd/no-ui-in-business-logic"]);
+  });
+
+  it("does not crash when uiLayers default value is used (regression for Set/.some)", async () => {
+    const messages = await lintText(
+      'import { Header } from "@app/widgets/Header";',
+      "src/features/auth/model/session.ts",
+      {
+        "fsd/no-ui-in-business-logic": [
+          "error",
+          { businessLogicLayers: ["features"] },
+        ],
+      },
+    );
+
+    expect(ruleIds(messages)).toEqual(["fsd/no-ui-in-business-logic"]);
   });
 });
 


### PR DESCRIPTION
## Description
Re-targets the changes from #28 onto `main`. PR #28 was merged into the now-stale `feat/issue-26-fs-import-resolver` branch after #27 had already merged into `main`, so its commits never reached `main`. This PR carries the same content forward so it can be included in v1.2.0.

Original work: fixes two pre-existing bugs surfaced while building the comprehensive FSD test suite for issue #26.

1. `fsd/no-ui-in-business-logic` crashed with `TypeError: uiLayers.some is not a function` whenever the rule reached its UI segment check. The cause was building `uiLayers` with `new Set(...)` and then calling `.some()`.
2. `fsd/no-ui-in-business-logic` and `fsd/no-relative-imports` only listened for `CallExpression` with `callee.type === "Import"`, which never matches under modern parsers (espree from ESLint v9 and `@typescript-eslint/parser` emit `ImportExpression`).

## Changes
- Stop wrapping `uiLayers` in `new Set(...)` in `src/rules/no-ui-in-business-logic.js`. The defaults remain `["ui", "widgets", "features"]`, but the value is kept as an array so `.some()` works.
- Extract the import check in `src/rules/no-ui-in-business-logic.js` into a shared `checkImport(node, importPath, { isTypeImport })` helper and route `ImportDeclaration`, `CallExpression`, and the new `ImportExpression` listener through it.
- Apply the same `checkImport` extraction and `ImportExpression` listener in `src/rules/no-relative-imports.js`.
- Restore the stronger `fsd/no-ui-in-business-logic` cases in `tests/fsd-comprehensive.test.js` that had to be softened in #27 around the crash. Add a default-config regression test for the Set/.some path and a dynamic-import regression test that exercises the new `ImportExpression` handler.

## Before / After
| Case | Before | After |
| --- | --- | --- |
| `fsd/no-ui-in-business-logic` reaching the UI check | Throws `TypeError: uiLayers.some is not a function` | Reports `noUiInBusinessLogic` correctly |
| Dynamic `import("@features/auth/ui/...")` from a business-logic file | Silently allowed under modern parsers | Reported by `fsd/no-ui-in-business-logic` |
| Dynamic relative `import("../../foo")` across slices | Silently allowed under modern parsers | Reported by `fsd/no-relative-imports` |
| Test count for `fsd/no-ui-in-business-logic` in `fsd-comprehensive` | 4 cases (softened around the crash) | 9 cases including regression coverage |

## Type of Change
- [ ] Documentation
- [x] Bug fix
- [ ] Feature
- [x] Refactoring
- [ ] Other (describe below)

## How to Test
- `npm run format:check`
- `npm run lint`
- `npm run lint:test-project`
- `npm run lint:test-project-next`
- `npm test` — 12 files, 197 tests

## Additional Information
- Replaces #28, which was merged into a stale feat branch instead of `main`.
- A separate pre-existing issue around `RuleTester` integration in `tests/rules/*.js` was identified during this work and is intentionally not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)